### PR TITLE
add escActionHandler for #211 (Ctrl-G in Emacs mode)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ intellij {
 }
 
 group = "com.johnlindquist"
-version = "3.5.0"
+version = "3.5.0-add-esc-action-handler"
 
 repositories.mavenCentral()
 dependencies.testCompile("io.reactivex.rxjava2:rxkotlin:2.2.0")


### PR DESCRIPTION
Since AceJump is derived from "ace-jump-mode" of Emacs,
I think that many users make Keymap as Emacs.

It is an already closed issue (#211)
Please adopt it if you like.