### PR TITLE
Don't restore scroll and caret on disposed editor

### DIFF
--- a/src/main/kotlin/org/acejump/control/Handler.kt
+++ b/src/main/kotlin/org/acejump/control/Handler.kt
@@ -150,9 +150,13 @@ object Handler : TypedActionHandler, Resettable {
     EditorColorsManager.getInstance().globalScheme.getAttributes(TEXT_SEARCH_RESULT_ATTRIBUTES)
       ?.backgroundColor.let { Model.naturalHighlight = it }
 
-  private fun Editor.restoreCaret() = runNow {
-    settings.isBlinkCaret = Model.naturalBlink
-    settings.isBlockCursor = Model.naturalBlock
+  private fun Editor.restoreCaret() {
+    if (!isDisposed) {
+      runNow {
+        settings.isBlinkCaret = Model.naturalBlink
+        settings.isBlockCursor = Model.naturalBlock
+      }
+    }
   }
 
   private fun Editor.restoreColors() = runNow {

--- a/src/main/kotlin/org/acejump/control/Scroller.kt
+++ b/src/main/kotlin/org/acejump/control/Scroller.kt
@@ -92,7 +92,7 @@ object Scroller {
   }
 
   fun Editor.restoreScroll() {
-    if (caretModel.offset !in getView()) {
+    if (!isDisposed && caretModel.offset !in getView()) {
       scrollingModel.scrollVertically(scrollY)
       scrollingModel.scrollHorizontally(scrollX)
     }


### PR DESCRIPTION
Fix #297