### PR TITLE
Remove green flashes after performing regex search

### DIFF
--- a/src/main/kotlin/org/acejump/view/Marker.kt
+++ b/src/main/kotlin/org/acejump/view/Marker.kt
@@ -58,7 +58,7 @@ class Marker : CustomHighlighterRenderer {
     queryLength = query.length - if(endsWith) 1 else 0
     trueOffset = query.length - 1
 
-    searchWidth = queryLength * fontWidth
+    searchWidth = if (regex) 0 else queryLength * fontWidth
 
     var i = 1
     while (i < query.length && index + i < text.length &&


### PR DESCRIPTION
After the performing regex search, small green flashes appear in the editor. Looks like IJ tries to paint the marks with the length of the regex pattern, but it should not happen in regex mode.

With this pull request, I suggest to explicitly set searchWidth to 0 in case of regex search.

![Screen Recording 2019-10-08 at 15 01 18](https://user-images.githubusercontent.com/4203721/66766697-67d5c700-eeb7-11e9-8155-a11225ce83f3.gif)
