### PR TITLE
IdeaVim integration

### DIFF
--- a/src/main/kotlin/org/acejump/control/Handler.kt
+++ b/src/main/kotlin/org/acejump/control/Handler.kt
@@ -55,6 +55,9 @@ object Handler : TypedActionHandler, Resettable {
   fun regexSearch(regex: Pattern, bounds: Boundary = FULL_FILE_BOUNDARY) =
     Canvas.reset().also { Finder.search(regex, bounds) }
 
+  fun customRegexSearch(regex: String, bounds: Boundary = FULL_FILE_BOUNDARY) =
+    Canvas.reset().also { Finder.search(regex, bounds) }
+
   fun activate() = if (!enabled) configureEditor() else { }
 
   private fun clear() {

--- a/src/main/kotlin/org/acejump/control/Handler.kt
+++ b/src/main/kotlin/org/acejump/control/Handler.kt
@@ -52,9 +52,11 @@ object Handler : TypedActionHandler, Resettable {
     override fun doExecute(e: Editor, c: Caret?, dc: DataContext?) = handle()
   }
 
+  @ExternalUsage
   fun regexSearch(regex: Pattern, bounds: Boundary = FULL_FILE_BOUNDARY) =
     Canvas.reset().also { Finder.search(regex, bounds) }
 
+  @ExternalUsage
   fun customRegexSearch(regex: String, bounds: Boundary = FULL_FILE_BOUNDARY) =
     Canvas.reset().also { Finder.search(regex, bounds) }
 
@@ -123,10 +125,12 @@ object Handler : TypedActionHandler, Resettable {
     editor.restoreSettings()
   }
 
+  @ExternalUsage
   fun addAceJumpListener(listener: AceJumpListener) {
     listeners += listener
   }
 
+  @ExternalUsage
   fun removeAceJumpListener(listener: AceJumpListener) {
     listeners -= listener
   }

--- a/src/main/kotlin/org/acejump/search/AceUtil.kt
+++ b/src/main/kotlin/org/acejump/search/AceUtil.kt
@@ -276,3 +276,12 @@ fun Editor.normalizeLine(line: Int) = max(0, min(line, getLineCount() - 1))
 fun Editor.normalizeOffset(line: Int, offset: Int, allowEnd: Boolean) =
   if (getFileSize(allowEnd) == 0) 0 else
     max(min(offset, getLineEndOffset(line, allowEnd)), getLineStartOffset(line))
+
+/**
+ * This annotation is a marker which means that the annotated function is
+ *   used in external plugins.
+ */
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FUNCTION)
+annotation class ExternalUsage

--- a/src/main/kotlin/org/acejump/search/Finder.kt
+++ b/src/main/kotlin/org/acejump/search/Finder.kt
@@ -113,6 +113,7 @@ object Finder : Resettable {
    *   AceFindModel should be empty. Additionally, if
    *   AceFindModes.isRegex == true, only one symbol is highlighted in document.
    */
+  @ExternalUsage
   fun markResults(
     results: SortedSet<Int>,
     model: AceFindModel = AceFindModel("", true)

--- a/src/main/kotlin/org/acejump/search/Finder.kt
+++ b/src/main/kotlin/org/acejump/search/Finder.kt
@@ -86,11 +86,15 @@ object Finder : Resettable {
 
   fun search(pattern: Pattern, bounds: Boundary = FULL_FILE_BOUNDARY) {
     logger.info("Searching for regular expression: ${pattern.name} in $bounds")
+    search(pattern.string, bounds)
+  }
+
+  fun search(pattern: String, bounds: Boundary = FULL_FILE_BOUNDARY) {
     boundaries = bounds
     // TODO: Fix this broken reset
     reset()
     Tagger.reset()
-    search(AceFindModel(pattern.string, true))
+    search(AceFindModel(pattern, true))
   }
 
   fun search(model: AceFindModel = AceFindModel(query)) {

--- a/src/main/kotlin/org/acejump/search/Finder.kt
+++ b/src/main/kotlin/org/acejump/search/Finder.kt
@@ -102,6 +102,21 @@ object Finder : Resettable {
       results = Scanner.findMatchingSites(editorText, model, results)
     }.let { logger.info("Found ${results.size} matching sites in $it ms") }
 
+    markResults(results, model)
+  }
+
+  /**
+   * This method should not be inlined because it's used in IdeaVim integration plugin
+   *
+   * The default model is like that because if this function was called from
+   *   the outer scope, it means that [results] are already collected and
+   *   AceFindModel should be empty. Additionally, if
+   *   AceFindModes.isRegex == true, only one symbol is highlighted in document.
+   */
+  fun markResults(
+    results: SortedSet<Int>,
+    model: AceFindModel = AceFindModel("", true)
+  ) {
     if (!skim) tag(model, results)
     markup(Tagger.markers, model)
   }

--- a/src/main/kotlin/org/acejump/view/Boundary.kt
+++ b/src/main/kotlin/org/acejump/view/Boundary.kt
@@ -38,5 +38,26 @@ enum class Boundary: ClosedRange<Int> {
       get() = max(editor.caretModel.offset, viewBounds.first)
     override val endInclusive: Int
       get() = viewBounds.last
+  },
+  // Search on the current line
+  CURRENT_LINE_BOUNDARY {
+    override val start: Int
+      get() = editor.document.getLineStartOffset(editor.caretModel.logicalPosition.line)
+    override val endInclusive: Int
+      get() = editor.document.getLineEndOffset(editor.caretModel.logicalPosition.line)
+  },
+  // Search after caret within line
+  CURRENT_LINE_AFTER_CARET_BOUNDARY {
+    override val start: Int
+    get() = max(editor.caretModel.offset, viewBounds.first)
+    override val endInclusive: Int
+    get() = editor.document.getLineEndOffset(editor.caretModel.logicalPosition.line)
+  },
+  // Search before caret within line
+  CURRENT_LINE_BEFORE_CARET_BOUNDARY {
+    override val start: Int
+    get() = editor.document.getLineStartOffset(editor.caretModel.logicalPosition.line)
+    override val endInclusive: Int
+    get() = min(editor.caretModel.offset, viewBounds.last)
   }
 }


### PR DESCRIPTION
With the power of AceJump it is possible to implement 80 of 87 easymotion commands. This is a wonderful result, I personally expected much fewer commands supported! The rest 7 commands don't seem to be a big deal as well but require a few extra days and more complicated changes in AceJump (some of the commands support jumps between editors). Anyway, we don't have any plans to implement the rest commands in the nearest future.

The result of the work is presented as a [IdeaVim-EasyMotion](https://github.com/AlexPl292/IdeaVim-EasyMotion) plugin. In order to make all the things work, we have to request some changes in the AceJump plugin. The given pull request consists out of 5 commits that provide some simple extensions of AceJump functionality. Below I'll describe the ideas behinds the commits. I don't insist on a particular design, function names or approaches, so I'll leave it up to the maintainers to use the commits offered or provide a better implementation.

1. Add listeners for AceJump lifecycle

If I don't miss something, currently there is no way to be notified about the acejump lifecycle. The IdeaVim-EasyMotion plugin should know when the AceJump has finished the work, so I've added a listener that does that. The listener contains only a `finished` method, but potentially other functions (like `started`) could be added as well. 

2. Custom regex search support

For some commands, EasyMotion constructs custom regex and performs the search using it.

3. Custom offsets provider support

Some other commands collect the offsets on their own. So, we need a way to just highlight the offsets and do the "tagging" stuff.
In this case, only one character should be highlighted in the editor. This can be reached by:
1) Using AceJumpModel with `regex` = true.
    Since the constructor of AceJumpModel has internal visibility, we have options to
    1.1) Use the default model as a parameter
    1.2) Make constructor of AceJumpModel public
2) Perform some work to make highlighting length configurable independent of AceJumpModel.

This commit uses 1.1 approach.

4. Add within line boundaries

This commit adds some new within line boundaries. Different approached can be used here as well (for example, convert enum to a class with constants and the possibility to create custom boundaries)

5. Mark some functions as externally used

This commit is not really required for EasyMotion, but at some point, I've found out that some of the functions have no usages in the project, but are used in EasyMotion plugin. So, here @ExternalUsage annotation is provided just to mark such functions and do not forget about that in case of refactoring.

As I said above, all the commits are "proposals" and all this can be changed in order to provide a better architecture of AceJump.