### PR TITLE
Apply the name of the archive only to the result of buildPlugin task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,15 +7,14 @@ tasks {
     kotlinOptions.freeCompilerArgs += "-progressive"
   }
 
-  named("buildPlugin") { dependsOn("test") }
+  named<Zip>("buildPlugin") {
+    dependsOn("test")
+    archiveFileName.set("AceJump.zip")
+  }
 
   withType<RunIdeTask> {
     dependsOn("test")
     findProperty("luginDev")?.let { args = listOf(projectDir.absolutePath) }
-  }
-
-  withType<Zip> {
-    archiveFileName.set("AceJump.zip")
   }
 }
 


### PR DESCRIPTION
I suppose that [this](https://github.com/JetBrains/gradle-intellij-plugin/issues/377) question was regarding the name of the resulting plugin archive.
With the existing script, the naming rule will apply to the *all* zip tasks, which is incorrect. This fact causes the problem that AceJump currently has a bit "incorrect" structure and even IJ plugin marketplace resolved it fine, it's a bit tricky to make a dependency to AceJump. `intellij` section in gradle script just cannot resolve such structure and it's needed to add the dependency manually.

This pull request reduces the naming rule only to the result of the `buildPlugin` task.

Additionally, here is a pic of the existing plugin structure:

<img width="821" alt="Screenshot 2019-10-31 at 16 11 15" src="https://user-images.githubusercontent.com/4203721/67950638-0756c180-fbfb-11e9-8d06-35a7d9da3ca6.png">

And here is a fixed structure:

<img width="836" alt="Screenshot 2019-10-31 at 16 09 53" src="https://user-images.githubusercontent.com/4203721/67950664-1a699180-fbfb-11e9-9eb6-1ee67d387905.png">
