### PR TITLE
Quickfix for for circular dependency between AceConfig and Pattern

### DIFF
--- a/src/main/kotlin/org/acejump/config/AceConfig.kt
+++ b/src/main/kotlin/org/acejump/config/AceConfig.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.options.Configurable
 import org.acejump.label.Pattern
 import org.acejump.label.Pattern.Companion.KeyLayout
+import org.acejump.label.mapIndices
 import java.awt.Color
 
 /**
@@ -32,10 +33,57 @@ object AceConfig: Configurable, PersistentStateComponent<AceSettings> {
   val tagBackgroundColor: Color get() = settings.tagBackgroundColor
   val supportPinyin: Boolean get() = settings.supportPinyin
 
+  private val nearby: Map<Char, Map<Char, Int>> = mapOf(
+    // Values are QWERTY keys sorted by physical proximity to the map key
+    'j' to "jikmnhuolbgypvftcdrxsezawq8796054321",
+    'f' to "ftgvcdryhbxseujnzawqikmolp5463728190",
+    'k' to "kolmjipnhubgyvftcdrxsezawq9807654321",
+    'd' to "drfcxsetgvzawyhbqujnikmolp4352617890",
+    'l' to "lkopmjinhubgyvftcdrxsezawq0987654321",
+    's' to "sedxzawrfcqtgvyhbujnikmolp3241567890",
+    'a' to "aqwszedxrfctgvyhbujnikmolp1234567890",
+    'h' to "hujnbgyikmvftolcdrpxsezawq6758493021",
+    'g' to "gyhbvftujncdrikmxseolzawpq5647382910",
+    'y' to "yuhgtijnbvfrokmcdeplxswzaq6758493021",
+    't' to "tygfruhbvcdeijnxswokmzaqpl5647382910",
+    'u' to "uijhyokmnbgtplvfrcdexswzaq7869504321",
+    'r' to "rtfdeygvcxswuhbzaqijnokmpl4536271890",
+    'n' to "nbhjmvgyuiklocftpxdrzseawq7685940321",
+    'v' to "vcfgbxdrtyhnzseujmawikqolp5463728190",
+    'm' to "mnjkbhuilvgyopcftxdrzseawq8970654321",
+    'c' to "cxdfvzsertgbawyhnqujmikolp4352617890",
+    'b' to "bvghncftyujmxdrikzseolawqp6574839201",
+    'i' to "iokjuplmnhybgtvfrcdexswzaq8970654321",
+    'e' to "erdswtfcxzaqygvuhbijnokmpl3425167890",
+    'x' to "xzsdcawerfvqtgbyhnujmikolp3241567890",
+    'z' to "zasxqwedcrfvtgbyhnujmikolp1234567890",
+    'o' to "oplkimjunhybgtvfrcdexswzaq9087654321",
+    'w' to "wesaqrdxztfcygvuhbijnokmpl2314567890",
+    'p' to "plokimjunhybgtvfrcdexswzaq0987654321",
+    'q' to "qwaeszrdxtfcygvuhbijnokmpl1234567890",
+    '1' to "1234567890qawzsexdrcftvgybhunjimkolp",
+    '2' to "2134567890qwasezxdrcftvgybhunjimkolp",
+    '3' to "3241567890weqasdrzxcftvgybhunjimkolp",
+    '4' to "4352617890erwsdftqazxcvgybhunjimkolp",
+    '5' to "5463728190rtedfgywsxcvbhuqaznjimkolp",
+    '6' to "6574839201tyrfghuedcvbnjiwsxmkoqazlp",
+    '7' to "7685940321yutghjirfvbnmkoedclpwsxqaz",
+    '8' to "8796054321uiyhjkotgbnmlprfvedcwsxqaz",
+    '9' to "9807654321ioujklpyhnmtgbrfvedcwsxqaz",
+    '0' to "0987654321opiklujmyhntgbrfvedcwsxqaz")
+    .mapValues { it.value.mapIndices() }
+
+  private fun distance(fromKey: Char, toKey: Char) = nearby[fromKey]!![toKey]
+
+  val defaultTagOrder: Comparator<String> = compareBy(
+    { it[0].isDigit() || it[1].isDigit() },
+    { distance(it[0], it.last()) },
+    layout.priority { it[0] })
+
   private var allPossibleTags: Set<String> = settings.allowedChars.bigrams()
 
   private fun String.bigrams() = run { flatMap { e -> map { c -> "$e$c" } } }
-      .sortedWith(Pattern.defaultTagOrder).toSet()
+      .sortedWith(defaultTagOrder).toSet()
 
   fun getCompatibleTags(query: String, matching: (String) -> Boolean) =
     Pattern.filter(allPossibleTags, query).filter(matching).toSet()

--- a/src/main/kotlin/org/acejump/label/Pattern.kt
+++ b/src/main/kotlin/org/acejump/label/Pattern.kt
@@ -16,13 +16,6 @@ enum class Pattern(val string: String) {
   ALL_WORDS("(?<=[^a-zA-Z0-9_]|\\A)[a-zA-Z0-9_]");
 
   companion object {
-    private fun distance(fromKey: Char, toKey: Char) = nearby[fromKey]!![toKey]
-
-    val defaultTagOrder: Comparator<String> = compareBy(
-      { it[0].isDigit() || it[1].isDigit() },
-      { distance(it[0], it.last()) },
-      AceConfig.layout.priority { it[0] })
-
     val NUM_TAGS: Int
       get() = NUM_CHARS * NUM_CHARS
 
@@ -70,46 +63,6 @@ enum class Pattern(val string: String) {
 
       fun joinBy(separator: CharSequence) = rows.joinToString(separator)
     }
-
-    private val nearby: Map<Char, Map<Char, Int>> = mapOf(
-      // Values are QWERTY keys sorted by physical proximity to the map key
-      'j' to "jikmnhuolbgypvftcdrxsezawq8796054321",
-      'f' to "ftgvcdryhbxseujnzawqikmolp5463728190",
-      'k' to "kolmjipnhubgyvftcdrxsezawq9807654321",
-      'd' to "drfcxsetgvzawyhbqujnikmolp4352617890",
-      'l' to "lkopmjinhubgyvftcdrxsezawq0987654321",
-      's' to "sedxzawrfcqtgvyhbujnikmolp3241567890",
-      'a' to "aqwszedxrfctgvyhbujnikmolp1234567890",
-      'h' to "hujnbgyikmvftolcdrpxsezawq6758493021",
-      'g' to "gyhbvftujncdrikmxseolzawpq5647382910",
-      'y' to "yuhgtijnbvfrokmcdeplxswzaq6758493021",
-      't' to "tygfruhbvcdeijnxswokmzaqpl5647382910",
-      'u' to "uijhyokmnbgtplvfrcdexswzaq7869504321",
-      'r' to "rtfdeygvcxswuhbzaqijnokmpl4536271890",
-      'n' to "nbhjmvgyuiklocftpxdrzseawq7685940321",
-      'v' to "vcfgbxdrtyhnzseujmawikqolp5463728190",
-      'm' to "mnjkbhuilvgyopcftxdrzseawq8970654321",
-      'c' to "cxdfvzsertgbawyhnqujmikolp4352617890",
-      'b' to "bvghncftyujmxdrikzseolawqp6574839201",
-      'i' to "iokjuplmnhybgtvfrcdexswzaq8970654321",
-      'e' to "erdswtfcxzaqygvuhbijnokmpl3425167890",
-      'x' to "xzsdcawerfvqtgbyhnujmikolp3241567890",
-      'z' to "zasxqwedcrfvtgbyhnujmikolp1234567890",
-      'o' to "oplkimjunhybgtvfrcdexswzaq9087654321",
-      'w' to "wesaqrdxztfcygvuhbijnokmpl2314567890",
-      'p' to "plokimjunhybgtvfrcdexswzaq0987654321",
-      'q' to "qwaeszrdxtfcygvuhbijnokmpl1234567890",
-      '1' to "1234567890qawzsexdrcftvgybhunjimkolp",
-      '2' to "2134567890qwasezxdrcftvgybhunjimkolp",
-      '3' to "3241567890weqasdrzxcftvgybhunjimkolp",
-      '4' to "4352617890erwsdftqazxcvgybhunjimkolp",
-      '5' to "5463728190rtedfgywsxcvbhuqaznjimkolp",
-      '6' to "6574839201tyrfghuedcvbnjiwsxmkoqazlp",
-      '7' to "7685940321yutghjirfvbnmkoedclpwsxqaz",
-      '8' to "8796054321uiyhjkotgbnmlprfvedcwsxqaz",
-      '9' to "9807654321ioujklpyhnmtgbrfvedcwsxqaz",
-      '0' to "0987654321opiklujmyhntgbrfvedcwsxqaz")
-      .mapValues { it.value.mapIndices() }
   }
 }
 

--- a/src/main/kotlin/org/acejump/label/Solver.kt
+++ b/src/main/kotlin/org/acejump/label/Solver.kt
@@ -1,9 +1,10 @@
 package org.acejump.label
 
-import com.google.common.collect.*
+import com.google.common.collect.Multimaps
+import com.google.common.collect.Ordering
+import com.google.common.collect.TreeMultimap
 import com.intellij.openapi.diagnostic.Logger
 import org.acejump.config.AceConfig
-import org.acejump.label.Pattern.Companion.defaultTagOrder
 import org.acejump.search.wordBoundsPlus
 import kotlin.collections.set
 import kotlin.math.max
@@ -86,7 +87,7 @@ class Solver(val text: String,
    * @see isCompatibleWithTagChar This defines how tags may be assigned to sites
    */
 
-  private val tagOrder = defaultTagOrder
+  private val tagOrder = AceConfig.defaultTagOrder
     .thenBy { eligibleSitesByTag[it].size }
     .thenBy(AceConfig.layout.priority { it.last() })
 

--- a/src/main/kotlin/org/acejump/label/Tagger.kt
+++ b/src/main/kotlin/org/acejump/label/Tagger.kt
@@ -5,13 +5,44 @@ import com.google.common.collect.HashBiMap
 import com.intellij.openapi.diagnostic.Logger
 import org.acejump.config.AceConfig
 import org.acejump.control.Scroller
-import org.acejump.label.Pattern.Companion.defaultTagOrder
-import org.acejump.search.*
+import org.acejump.search.AceFindModel
+import org.acejump.search.Finder
+import org.acejump.search.Jumper
+import org.acejump.search.Resettable
+import org.acejump.search.canIndicesBeSimultaneouslyVisible
+import org.acejump.search.getFeasibleRegion
+import org.acejump.search.runNow
 import org.acejump.view.Marker
 import org.acejump.view.Model.editor
 import org.acejump.view.Model.editorText
 import org.acejump.view.Model.viewBounds
 import java.util.*
+import kotlin.collections.Iterable
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.collections.Set
+import kotlin.collections.all
+import kotlin.collections.any
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.contains
+import kotlin.collections.emptyList
+import kotlin.collections.filter
+import kotlin.collections.firstOrNull
+import kotlin.collections.isNotEmpty
+import kotlin.collections.iterator
+import kotlin.collections.joinToString
+import kotlin.collections.lastOrNull
+import kotlin.collections.map
+import kotlin.collections.mapKeysTo
+import kotlin.collections.none
+import kotlin.collections.partition
+import kotlin.collections.plus
+import kotlin.collections.sortedSetOf
+import kotlin.collections.sortedWith
+import kotlin.collections.toMap
+import kotlin.collections.toSortedSet
+import kotlin.collections.zip
 import kotlin.streams.toList
 import kotlin.system.measureTimeMillis
 
@@ -243,7 +274,7 @@ object Tagger : Resettable {
   }
 
   private fun solveRegex(vacantResults: List<Int>, availableTags: Set<String>) =
-    availableTags.sortedWith(defaultTagOrder).zip(vacantResults).toMap()
+    availableTags.sortedWith(AceConfig.defaultTagOrder).zip(vacantResults).toMap()
 
   /**
    * Adds pre-existing tags where search string and tag overlap. For example,


### PR DESCRIPTION
Hey @breandan,
looks like there is a circular dependency between AceConfig and Pattern initialization.
[Here](https://github.com/acejump/AceJump/blob/master/src/main/kotlin/org/acejump/label/Pattern.kt#L24) `AceConfig` is needed for `Pattern` and [here](https://github.com/acejump/AceJump/blob/master/src/main/kotlin/org/acejump/config/AceConfig.kt#L38) `Pattern` is required for `AceConfig`.

If you don't see any good fix for this, here is my quickfix solution that can be used for the release before the proper one. 👍 