### PR TITLE
Fixed several performance issues and stuttering

### DIFF
--- a/src/main/kotlin/org/acejump/control/Listener.kt
+++ b/src/main/kotlin/org/acejump/control/Listener.kt
@@ -22,6 +22,7 @@ import kotlin.system.measureTimeMillis
 
 internal object Listener: FocusListener, AncestorListener, VisibleAreaListener {
   private val logger = Logger.getInstance(Listener::class.java)
+  private val redoFindTrigger = Trigger()
 
   fun enable() =
   // TODO: Do we really need `synchronized` here?
@@ -55,8 +56,8 @@ internal object Listener: FocusListener, AncestorListener, VisibleAreaListener {
         return
       }
     }
-    elapsed = (750L - elapsed).coerceAtLeast(0L)
-    Trigger(withDelay = elapsed) {
+    elapsed = (350L - elapsed).coerceAtLeast(0L)
+    redoFindTrigger(withDelay = elapsed) {
       logger.info("Visible area changed")
       redoFind()
     }

--- a/src/main/kotlin/org/acejump/control/Selector.kt
+++ b/src/main/kotlin/org/acejump/control/Selector.kt
@@ -19,10 +19,13 @@ object Selector {
     if (matches.size == 1 && wasAlreadyVisible) Handler.reset()
   }
 
-  fun nearestVisibleMatches(forward: Boolean = true) =
-    Finder.visibleResults().sortedWith(compareBy(
+  fun nearestVisibleMatches(forward: Boolean = true): List<Int> {
+    val caretOffset = caretOffset
+
+    return Finder.visibleResults().sortedWith(compareBy(
       { it == caretOffset },
       { (it <= caretOffset) == forward },
       { if (forward) it - caretOffset else caretOffset - it }
     ))
+  }
 }

--- a/src/main/kotlin/org/acejump/control/Trigger.kt
+++ b/src/main/kotlin/org/acejump/control/Trigger.kt
@@ -2,47 +2,40 @@ package org.acejump.control
 
 import com.intellij.openapi.diagnostic.Logger
 import org.acejump.search.runLater
-import java.lang.System.currentTimeMillis
-import kotlin.math.abs
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 
 /**
  * Timer for triggering events with a designated delay.
  */
 
-object Trigger: () -> Unit {
-  private val logger = Logger.getInstance(Trigger::class.java)
-  private var delay = 0L
-  private var timer = currentTimeMillis()
-  private var isRunning = false
-  private var invokable: () -> Unit = {}
-
-  override fun invoke() {
-    timer = currentTimeMillis()
-    if (isRunning) return
-    synchronized(this) {
-      isRunning = true
-
-      while (currentTimeMillis() - timer <= delay)
-        Thread.sleep(abs(delay - (currentTimeMillis() - timer)))
-
-      try {
-        invokable()
-      } catch (e: Exception) {
-        logger.error("Exception occurred while triggering event!", e)
-      }
-
-      isRunning = false
-    }
+class Trigger {
+  private companion object {
+    private val executor = Executors.newSingleThreadScheduledExecutor()
   }
+
+  private val logger = Logger.getInstance(Trigger::class.java)
+  private var task: Future<*>? = null
 
   /**
    * Can be called multiple times inside [delay], but doing so will reset the
    * timer, delaying the [event] from occurring by [withDelay] milliseconds.
    */
 
-  operator fun invoke(withDelay: Long = 750, event: () -> Unit = {}) {
-    delay = withDelay
-    invokable = event
-    runLater(this)
+  @Synchronized
+  operator fun invoke(withDelay: Long, event: () -> Unit = {}) {
+    task?.cancel(true)
+    task = executor.schedule({
+      runLater {
+        try {
+          event()
+        } catch (e: Exception) {
+          logger.error("Exception occurred while triggering event!", e)
+        } finally {
+          task = null
+        }
+      }
+    }, withDelay, TimeUnit.MILLISECONDS)
   }
 }

--- a/src/main/kotlin/org/acejump/label/Pattern.kt
+++ b/src/main/kotlin/org/acejump/label/Pattern.kt
@@ -42,8 +42,8 @@ enum class Pattern(val string: String) {
       QGMLWB("1234567890", "qgmlwbyuv", "dstnriaeoh", "zxcfjkp"),
       NORMAN("1234567890", "qwdfkjurl", "asetgynioh", "zxcvbpm");
 
-      private val priority
-        get() = when (this) {
+      private val priority by lazy {
+        when (this) {
           QWERTY -> "fjghdkslavncmbxzrutyeiwoqp5849673210"
           QWERTZ -> "fjghdkslavncmbxyrutzeiwoqp5849673210"
           COLEMK -> "tndhseriaovkcmbxzgjplfuwyq5849673210"
@@ -53,6 +53,7 @@ enum class Pattern(val string: String) {
           QGMLWB -> "naterisodhfkcpjxzlymuwbgvq5849673210"
           WORKMN -> "tnhegysoaiclvkmxzwfrubjdpq5849673210"
         }.mapIndices()
+      }
 
       val text by lazy {
         joinBy("").toCharArray().sortedBy { priority[it] }.joinToString("")

--- a/src/main/kotlin/org/acejump/label/Solver.kt
+++ b/src/main/kotlin/org/acejump/label/Solver.kt
@@ -157,13 +157,20 @@ class Solver(val text: String,
         sortWith(tagOrder)
       }
 
+      val matchingSites = HashMap<IntList, IntArray>()
+      val matchingSitesAsArrays = HashMap<String, IntArray>()
+
+      for ((key, value) in eligibleSitesByTag.entries) {
+        matchingSitesAsArrays[key] = matchingSites.getOrPut(value){
+          value.toIntArray().apply { IntArrays.mergeSort(this, siteOrder) }
+        }
+      }
+
       timeAssigned = measureTimeMillis {
         for (tag in sortedTags) {
           if (totalAssigned == results.size) break
-
-          val eligibleSites = eligibleSitesByTag.getValue(tag)
-          eligibleSites.sort(siteOrder)
-          if (tryToAssignTag(tag, eligibleSites.toIntArray())) totalAssigned++
+          if (tryToAssignTag(tag, matchingSitesAsArrays.getValue(tag)))
+            totalAssigned++
         }
       }
     }

--- a/src/main/kotlin/org/acejump/label/Solver.kt
+++ b/src/main/kotlin/org/acejump/label/Solver.kt
@@ -203,7 +203,8 @@ class Solver(val text: String,
   private fun getWordFragments(site: Int): List<String> {
     val left = max(0, site + query.length - 1)
     val right = text.wordBoundsPlus(site).second
+    val lowercase = text.substring(left, right).toLowerCase()
 
-    return (left..right).map { text.substring(left, it).toLowerCase() }
+    return (0..(right - left)).map { lowercase.substring(0, it) }
   }
 }

--- a/src/main/kotlin/org/acejump/search/AceUtil.kt
+++ b/src/main/kotlin/org/acejump/search/AceUtil.kt
@@ -69,9 +69,13 @@ fun String.wordBounds(index: Int): Pair<Int, Int> {
 fun String.wordBoundsPlus(index: Int): Pair<Int, Int> {
   var (left, right) = wordBounds(index)
 
-  (right..(right + 3).coerceAtMost(length - 1)).asSequence()
-    .takeWhile { !(get(it) == '\n' || get(it) == '\r') }
-    .forEach { right = it }
+  for (it in (right..(right + 3).coerceAtMost(length - 1))) {
+    if (get(it) == '\n' || get(it) == '\r') {
+      break
+    } else {
+      right = it
+    }
+  }
 
   return left to right
 }
@@ -86,8 +90,8 @@ fun defaultEditor(): Editor =
 
 fun Editor.getPoint(idx: Int) = visualPositionToXY(offsetToVisualPosition(idx))
 
-fun Editor.getPointRelative(index: Int, relativeToComponent: JComponent) =
-  RelativePoint(relativeToComponent, getPoint(index)).originalPoint
+fun Editor.getPointRelative(absolute: Point, relativeToComponent: JComponent) =
+  RelativePoint(relativeToComponent, absolute).originalPoint
 
 fun Editor.isFirstCharacterOfLine(index: Int) =
   index == getLineStartOffset(offsetToLogicalPosition(index).line)

--- a/src/main/kotlin/org/acejump/search/AceUtil.kt
+++ b/src/main/kotlin/org/acejump/search/AceUtil.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.ui.awt.RelativePoint
+import com.intellij.util.IntPair
 import org.acejump.view.Model.MAX_TAG_RESULTS
 import org.acejump.view.Model.viewBounds
 import java.awt.Point
@@ -59,14 +60,18 @@ fun Editor.isNotFolded(offset: Int) = !foldingModel.isOffsetCollapsed(offset)
  * is seen on either side.
  */
 
-fun String.wordBounds(index: Int): Pair<Int, Int> {
-  var (first, last) = index to index
+fun String.wordBounds(index: Int): IntPair {
+  var first = index
+  var last = index
   while (0 < first && get(first - 1).isJavaIdentifierPart()) first--
   while (last < length && get(last).isJavaIdentifierPart()) last++
-  return first to last
+  return IntPair(first, last)
 }
 
-fun String.wordBoundsPlus(index: Int): Pair<Int, Int> {
+operator fun IntPair.component1() = this.first
+operator fun IntPair.component2() = this.second
+
+fun String.wordBoundsPlus(index: Int): IntPair {
   var (left, right) = wordBounds(index)
 
   for (it in (right..(right + 3).coerceAtMost(length - 1))) {
@@ -77,7 +82,7 @@ fun String.wordBoundsPlus(index: Int): Pair<Int, Int> {
     }
   }
 
-  return left to right
+  return IntPair(left, right)
 }
 
 fun defaultEditor(): Editor =

--- a/src/main/kotlin/org/acejump/search/Finder.kt
+++ b/src/main/kotlin/org/acejump/search/Finder.kt
@@ -32,6 +32,7 @@ object Finder : Resettable {
   private var textHighlights = listOf<RangeHighlighter>()
   private var HIGHLIGHT_LAYER = HighlighterLayer.LAST + 1
   private val logger = Logger.getInstance(Finder::class.java)
+  private val skimTrigger = Trigger()
   var isShiftSelectEnabled = false
 
   var skim = false
@@ -79,7 +80,7 @@ object Finder : Resettable {
       skim = true
       logger.info("Skimming document for matches of: $query")
       search()
-      Trigger(400L) { skim = false; search() }
+      skimTrigger(400L) { skim = false; search() }
     } else search()
 
   fun search(pattern: Pattern, bounds: Boundary = FULL_FILE_BOUNDARY) {

--- a/src/main/kotlin/org/acejump/view/Marker.kt
+++ b/src/main/kotlin/org/acejump/view/Marker.kt
@@ -70,8 +70,10 @@ class Marker {
 
     editor.run {
       start = getPoint(index)
-      srcPoint = getPointRelative(index, contentComponent)
-      tagPoint = getPointRelative(tgIdx, contentComponent)
+      srcPoint = getPointRelative(start, contentComponent)
+      tagPoint =
+        if (index == tgIdx) srcPoint
+        else getPointRelative(getPoint(tgIdx), contentComponent)
     }
 
     startY = start.y + rectVOffset


### PR DESCRIPTION
Was trying the plugin out and immediately ran into severe performance issues, so I figured I'd give some optimizations a shot.

Here are my results with the `test tag latency` test:
```
Before: 25.1s (avg 185ms)
After:   9.2s (avg  28ms)
```

I verified that unit tests succeed (apart from `test pinyin selection` which had a compile error in `master`, not sure if you know), and that the order of tags has not changed and basic uses of the plugin still work, but since I've only used it for a few minutes so far it's possible something subtle may have changed that I didn't catch.

### Rationale

In a few places I avoided recomputing things that don't change, those cases should be obvious.

In `Solver.tryToAssignTag`, the first major change was storing used indices in an `IntSet` which already brought it down from about 24s to about 17s. HashMap value collections are O(n), plus `IntSet` has the benefit of not boxing primitives. I also changed `newTags` into an `Object2IntOpenHashMap` to avoid boxing values. These collections come from fastutil included in IJ.

In `Solver.map`, I completely rewrote the collections and removed parallel streams. Regarding parallelization, I have a 16 thread CPU and the overhead of starting threads and synchronizing on the `TreeMultimap` was so large it took all the threads just to match the performance of single-threaded streams. Reducing the thread count made performance worse, so this parallel stream likely runs worse on any CPU with fewer than 16 threads than a non-parallel stream.

Still, the major bottleneck was `TreeMultimap`. I found that the values only needed to be in a sorted state by the time they get passed to `tryToAssignTag`, so I completely replaced the multimap with a `HashMap<String, IntList>` where `IntList` not only avoids boxing, but also supports primitive integer comparators for sorting, and has an efficient conversion to array.

Switching out the map and removing parallel streams brought it down from 17s to 11s. Replacing the boxed comparator with primitive comparator made the code a bit more verbose, but it also saved roughly 2 additional seconds. I noticed the collections end up rather large and this is probably close to the limit of what can be done without completely rewriting how tags are assigned.

In `AceUtil.wordBoundsPlus`, I turned the sequence into a simple loop, it didn't save much time but I didn't see any reason to use a sequence and allocate collections there.

Finally, the old implementation of `Trigger` appears to have been freezing the UI thread and didn't work as described in the documentation comment (it wasn't resetting the timer on repeated calls despite the comment saying so). My reimplementation probably isn't the best either, but with it and with the other optimizations, I was able to drop the `visibleAreaChanged` delay to about half with no stuttering.