### PR TITLE
Add option to only consider visible area and increase limit for what is considered a large file

### DIFF
--- a/src/main/kotlin/org/acejump/config/AceConfig.kt
+++ b/src/main/kotlin/org/acejump/config/AceConfig.kt
@@ -37,6 +37,7 @@ class AceConfig: PersistentStateComponent<AceSettings> {
     val textHighlightColor: Color get() = settings.textHighlightColor
     val tagForegroundColor: Color get() = settings.tagForegroundColor
     val tagBackgroundColor: Color get() = settings.tagBackgroundColor
+    val searchWholeFile: Boolean get() = settings.searchWholeFile
     val supportPinyin: Boolean get() = settings.supportPinyin
 
     private val nearby: Map<Char, Map<Char, Int>> = mapOf(

--- a/src/main/kotlin/org/acejump/config/AceConfigurable.kt
+++ b/src/main/kotlin/org/acejump/config/AceConfigurable.kt
@@ -23,6 +23,7 @@ class AceConfigurable: Configurable {
       panel.textHighlightColor != settings.textHighlightColor ||
       panel.tagForegroundColor != settings.tagForegroundColor ||
       panel.tagBackgroundColor != settings.tagBackgroundColor ||
+      panel.searchWholeFile != settings.searchWholeFile ||
       panel.supportPinyin != settings.supportPinyin
 
   private fun String.distinctAlphanumerics() =
@@ -42,6 +43,7 @@ class AceConfigurable: Configurable {
     panel.textHighlightColor ?.let { settings.textHighlightColor = it }
     panel.tagForegroundColor ?.let { settings.tagForegroundColor = it }
     panel.tagBackgroundColor ?.let { settings.tagBackgroundColor = it }
+    settings.searchWholeFile = panel.searchWholeFile
     settings.supportPinyin = panel.supportPinyin
 
     logger.info("User applied new settings: $settings")

--- a/src/main/kotlin/org/acejump/config/AceSettings.kt
+++ b/src/main/kotlin/org/acejump/config/AceSettings.kt
@@ -33,5 +33,6 @@ data class AceSettings(
   var tagBackgroundColor: Color = Color.YELLOW,
 
   var displayQuery: Boolean = false,
+  var searchWholeFile: Boolean = true,
   var supportPinyin: Boolean = false
 )

--- a/src/main/kotlin/org/acejump/config/AceSettingsPanel.kt
+++ b/src/main/kotlin/org/acejump/config/AceSettingsPanel.kt
@@ -34,6 +34,7 @@ internal class AceSettingsPanel {
   private val tagForegroundColorWheel = ColorPanel()
   private val tagBackgroundColorWheel = ColorPanel()
   private val displayQueryCheckBox = JBCheckBox().apply { isEnabled = false }
+  private val searchWholeFileCheckBox = JBCheckBox()
   private val supportPinyinCheckBox = JBCheckBox()
 
   init {
@@ -73,7 +74,8 @@ internal class AceSettingsPanel {
       row { short(displayQueryCheckBox.apply { text = aceString("displayQueryLabel") }) }
     }
 
-    titledRow(aceString("languagesHeading")) {
+    titledRow(aceString("behaviorHeading")) {
+      row { short(searchWholeFileCheckBox.apply { text = aceString("searchWholeFileLabel") }) }
       row { short(supportPinyinCheckBox.apply { text = aceString("supportPinyin") }) }
     }
   }
@@ -90,6 +92,7 @@ internal class AceSettingsPanel {
   internal var tagForegroundColor by tagForegroundColorWheel
   internal var tagBackgroundColor by tagBackgroundColorWheel
   internal var displayQuery by displayQueryCheckBox
+  internal var searchWholeFile by searchWholeFileCheckBox
   internal var supportPinyin by supportPinyinCheckBox
 
   fun reset(settings: AceSettings) {
@@ -102,6 +105,7 @@ internal class AceSettingsPanel {
     tagForegroundColor = settings.tagForegroundColor
     tagBackgroundColor = settings.tagBackgroundColor
     displayQuery = settings.displayQuery
+    searchWholeFile = settings.searchWholeFile
     supportPinyin = settings.supportPinyin
   }
 

--- a/src/main/kotlin/org/acejump/search/Scanner.kt
+++ b/src/main/kotlin/org/acejump/search/Scanner.kt
@@ -22,9 +22,9 @@ internal object Scanner {
    * will filter prior results instead of searching the editor contents.
    */
 
-  fun find(model: AceFindModel, cache: Set<Int> = emptySet()): SortedSet<Int> =
-    if (!LONG_DOCUMENT || cache.size != 0 || boundaries != FULL_FILE_BOUNDARY)
-      editorText.search(model, cache, boundaries.intRange()).toSortedSet()
+  fun find(model: AceFindModel, boundaries: IntRange, cache: Set<Int> = emptySet()): SortedSet<Int> =
+    if (!LONG_DOCUMENT || cache.size != 0 || boundaries != FULL_FILE_BOUNDARY.intRange())
+      editorText.search(model, cache, boundaries).toSortedSet()
     else editorText.chunk().parallelStream().map { chunk ->
       editorText.search(model, cache, chunk)
     }.toList().flatten().toSortedSet()

--- a/src/main/kotlin/org/acejump/search/Scanner.kt
+++ b/src/main/kotlin/org/acejump/search/Scanner.kt
@@ -1,9 +1,7 @@
 package org.acejump.search
 
 import com.intellij.openapi.diagnostic.Logger
-import org.acejump.view.Boundary.FULL_FILE_BOUNDARY
-import org.acejump.view.Model.LONG_DOCUMENT
-import org.acejump.view.Model.boundaries
+import org.acejump.view.Model.LONG_DOCUMENT_LENGTH
 import org.acejump.view.Model.editorText
 import java.util.*
 import kotlin.streams.toList
@@ -23,7 +21,7 @@ internal object Scanner {
    */
 
   fun find(model: AceFindModel, boundaries: IntRange, cache: Set<Int> = emptySet()): SortedSet<Int> =
-    if (!LONG_DOCUMENT || cache.size != 0 || boundaries != FULL_FILE_BOUNDARY.intRange())
+    if (cache.isNotEmpty() || (boundaries.last - boundaries.first) < LONG_DOCUMENT_LENGTH)
       editorText.search(model, cache, boundaries).toSortedSet()
     else editorText.chunk().parallelStream().map { chunk ->
       editorText.search(model, cache, chunk)

--- a/src/main/kotlin/org/acejump/view/Model.kt
+++ b/src/main/kotlin/org/acejump/view/Model.kt
@@ -56,9 +56,9 @@ object Model {
     get() = lineHeight - (editor as EditorImpl).descent - fontHeight
   val arcD = rectHeight - 6
   var viewBounds = 0..0
-  const val DEFAULT_BUFFER = 30000
+  const val LONG_DOCUMENT_LENGTH = 100000
   val LONG_DOCUMENT
-    get() = DEFAULT_BUFFER < editorText.length
+    get() = LONG_DOCUMENT_LENGTH < editorText.length
   const val MAX_TAG_RESULTS = 300
 
   val defaultBoundary = FULL_FILE_BOUNDARY

--- a/src/main/resources/AceResources.properties
+++ b/src/main/resources/AceResources.properties
@@ -11,5 +11,6 @@ tagForegroundColorLabel=Tag foreground:
 tagBackgroundColorLabel=Tag background:
 appearanceHeading=Appearance
 displayQueryLabel=Display search query
-languagesHeading=Language
+behaviorHeading=Behavior
+searchWholeFileLabel=Search whole file
 supportPinyin=Support Pinyin selection


### PR DESCRIPTION
Should resolve #217 by adding option to only search in visible area. As I mentioned in the issue, the boundary checks only consider lines, so it's still possible to improve this for files with very long lines but this is good for the vast majority of cases.

The second commit also increases the limit for what's considered a large file from 30k to 100k, and changes the decision, whether search should be parallelized, to consider the total boundary size instead of hard-coding it to full file (could be useful, for ex. if a file had *extremely* long lines where screen boundary is also huge, or if more boundaries where implemented such as one that searches from caret to end of a large file).