### PR TITLE
Add option to switch between straight and rounded tag corners

### DIFF
--- a/src/main/kotlin/org/acejump/config/AceConfig.kt
+++ b/src/main/kotlin/org/acejump/config/AceConfig.kt
@@ -37,6 +37,7 @@ class AceConfig: PersistentStateComponent<AceSettings> {
     val textHighlightColor: Color get() = settings.textHighlightColor
     val tagForegroundColor: Color get() = settings.tagForegroundColor
     val tagBackgroundColor: Color get() = settings.tagBackgroundColor
+    val roundedTagCorners: Boolean get() = settings.roundedTagCorners
     val supportPinyin: Boolean get() = settings.supportPinyin
 
     private val nearby: Map<Char, Map<Char, Int>> = mapOf(

--- a/src/main/kotlin/org/acejump/config/AceConfigurable.kt
+++ b/src/main/kotlin/org/acejump/config/AceConfigurable.kt
@@ -23,6 +23,7 @@ class AceConfigurable: Configurable {
       panel.textHighlightColor != settings.textHighlightColor ||
       panel.tagForegroundColor != settings.tagForegroundColor ||
       panel.tagBackgroundColor != settings.tagBackgroundColor ||
+      panel.roundedTagCorners != settings.roundedTagCorners ||
       panel.supportPinyin != settings.supportPinyin
 
   private fun String.distinctAlphanumerics() =
@@ -42,6 +43,7 @@ class AceConfigurable: Configurable {
     panel.textHighlightColor ?.let { settings.textHighlightColor = it }
     panel.tagForegroundColor ?.let { settings.tagForegroundColor = it }
     panel.tagBackgroundColor ?.let { settings.tagBackgroundColor = it }
+    settings.roundedTagCorners = panel.roundedTagCorners
     settings.supportPinyin = panel.supportPinyin
 
     logger.info("User applied new settings: $settings")

--- a/src/main/kotlin/org/acejump/config/AceSettings.kt
+++ b/src/main/kotlin/org/acejump/config/AceSettings.kt
@@ -33,5 +33,6 @@ data class AceSettings(
   var tagBackgroundColor: Color = Color.YELLOW,
 
   var displayQuery: Boolean = false,
+  var roundedTagCorners: Boolean = true,
   var supportPinyin: Boolean = false
 )

--- a/src/main/kotlin/org/acejump/config/AceSettingsPanel.kt
+++ b/src/main/kotlin/org/acejump/config/AceSettingsPanel.kt
@@ -34,6 +34,7 @@ internal class AceSettingsPanel {
   private val tagForegroundColorWheel = ColorPanel()
   private val tagBackgroundColorWheel = ColorPanel()
   private val displayQueryCheckBox = JBCheckBox().apply { isEnabled = false }
+  private val roundedTagCornersCheckBox = JBCheckBox()
   private val supportPinyinCheckBox = JBCheckBox()
 
   init {
@@ -71,6 +72,7 @@ internal class AceSettingsPanel {
 
     titledRow(aceString("appearanceHeading")) {
       row { short(displayQueryCheckBox.apply { text = aceString("displayQueryLabel") }) }
+      row { short(roundedTagCornersCheckBox.apply { text = aceString("roundedTagCornersLabel") }) }
     }
 
     titledRow(aceString("languagesHeading")) {
@@ -90,6 +92,7 @@ internal class AceSettingsPanel {
   internal var tagForegroundColor by tagForegroundColorWheel
   internal var tagBackgroundColor by tagBackgroundColorWheel
   internal var displayQuery by displayQueryCheckBox
+  internal var roundedTagCorners by roundedTagCornersCheckBox
   internal var supportPinyin by supportPinyinCheckBox
 
   fun reset(settings: AceSettings) {
@@ -102,6 +105,7 @@ internal class AceSettingsPanel {
     tagForegroundColor = settings.tagForegroundColor
     tagBackgroundColor = settings.tagBackgroundColor
     displayQuery = settings.displayQuery
+    roundedTagCorners = settings.roundedTagCorners
     supportPinyin = settings.supportPinyin
   }
 

--- a/src/main/kotlin/org/acejump/view/Model.kt
+++ b/src/main/kotlin/org/acejump/view/Model.kt
@@ -54,7 +54,8 @@ object Model {
     get() = fontHeight + 3
   val rectVOffset
     get() = lineHeight - (editor as EditorImpl).descent - fontHeight
-  val arcD = rectHeight - 6
+  val arcD
+    get() = if (AceConfig.roundedTagCorners) rectHeight - 6 else 1
   var viewBounds = 0..0
   const val DEFAULT_BUFFER = 30000
   val LONG_DOCUMENT

--- a/src/main/resources/AceResources.properties
+++ b/src/main/resources/AceResources.properties
@@ -11,5 +11,6 @@ tagForegroundColorLabel=Tag foreground:
 tagBackgroundColorLabel=Tag background:
 appearanceHeading=Appearance
 displayQueryLabel=Display search query
+roundedTagCornersLabel=Rounded tag corners
 languagesHeading=Language
 supportPinyin=Support Pinyin selection


### PR DESCRIPTION
On my particular configuration, the rounded corners often go underneath letters which makes them unnecessarily difficult to read, so I added an option to turn the rounding off.

![obrazek](https://user-images.githubusercontent.com/3685160/99925284-d71a1d80-2d3d-11eb-9cb7-5811ac90ec59.png)
