### PR TITLE
Pass information about query and mark in finish listener

### DIFF
--- a/src/main/kotlin/org/acejump/action/AceEditorAction.kt
+++ b/src/main/kotlin/org/acejump/action/AceEditorAction.kt
@@ -31,7 +31,7 @@ sealed class AceEditorAction(private val originalHandler: EditorActionHandler): 
   // Actions
 
   class Reset(originalHandler: EditorActionHandler): AceEditorAction(originalHandler) {
-    override fun run(session: Session) = session.end()
+    override fun run(session: Session) = session.end(false)
   }
 
   class ClearSearch(originalHandler: EditorActionHandler): AceEditorAction(originalHandler) {

--- a/src/main/kotlin/org/acejump/search/Tagger.kt
+++ b/src/main/kotlin/org/acejump/search/Tagger.kt
@@ -37,6 +37,10 @@ internal class Tagger(private val editor: Editor) {
     tagMap = HashBiMap.create()
   }
 
+  fun getMarkByOffset(offset: Int): String? {
+    return tagMap.inverse()[offset]
+  }
+
   /**
    * Assigns tags to as many results as possible, keeping previously assigned
    * tags. Returns a [TaggingResult.Jump] if the current search query matches

--- a/src/main/kotlin/org/acejump/session/AceJumpListener.kt
+++ b/src/main/kotlin/org/acejump/session/AceJumpListener.kt
@@ -1,5 +1,5 @@
 package org.acejump.session
 
 interface AceJumpListener {
-  fun finished()
+  fun finished(mark: String?, query: String?)
 }

--- a/src/main/kotlin/org/acejump/session/Session.kt
+++ b/src/main/kotlin/org/acejump/session/Session.kt
@@ -21,6 +21,7 @@ import org.acejump.input.JumpModeTracker
 import org.acejump.input.KeyLayoutCache
 import org.acejump.search.Pattern
 import org.acejump.search.SearchProcessor
+import org.acejump.search.SearchQuery
 import org.acejump.search.Tagger
 import org.acejump.search.TaggingResult
 import org.acejump.view.TagCanvas
@@ -47,7 +48,7 @@ class Session(private val editor: Editor) {
       field = value
 
       if (value === JumpMode.DISABLED) {
-        end()
+        end(false)
       } else {
         searchProcessor?.let { textHighlighter.render(it.results, it.query, jumpMode) }
         editor.colorsScheme.setColor(CARET_COLOR, value.caretColor)
@@ -124,7 +125,7 @@ class Session(private val editor: Editor) {
       is TaggingResult.Jump -> {
         tagJumper.jump(result.offset, shiftMode)
         tagCanvas.removeMarkers()
-        end()
+        end(true)
       }
 
       is TaggingResult.Mark -> {
@@ -204,17 +205,17 @@ class Session(private val editor: Editor) {
    * See [TagVisitor.visitPrevious]. If there are no tags, nothing happens.
    */
   fun visitPreviousTag() =
-    if (tagVisitor?.visitPrevious() == true) end() else Unit
+    if (tagVisitor?.visitPrevious() == true) end(true) else Unit
 
   /**
    * See [TagVisitor.visitNext]. If there are no tags, nothing happens.
    */
-  fun visitNextTag() = if (tagVisitor?.visitNext() == true) end() else Unit
+  fun visitNextTag() = if (tagVisitor?.visitNext() == true) end(true) else Unit
 
   /**
    * Ends this session.
    */
-  fun end() = SessionManager.end(editor)
+  fun end(jumpPerformed: Boolean) = SessionManager.end(editor, jumpPerformed)
 
   /**
    * Clears any currently active search, tags, and highlights.
@@ -231,19 +232,38 @@ class Session(private val editor: Editor) {
    * Should only be used from [SessionManager] to dispose a
    * successfully ended session.
    */
-  internal fun dispose() {
+  internal fun dispose(jumpPerformed: Boolean) {
+    val (mark, query) = calculateMarkAndQuery(jumpPerformed)
+
     tagger = Tagger(editor)
     EditorKeyListener.detach(editor)
     tagCanvas.unbind()
     textHighlighter.reset()
     EditorCache.invalidate()
-    listeners.forEach(AceJumpListener::finished)
+    listeners.forEach { it.finished(mark, query) }
 
     if (!editor.isDisposed) {
       originalSettings.restore(editor)
       editor.colorsScheme.setColor(CARET_COLOR, JumpMode.DISABLED.caretColor)
       editor.scrollingModel.scrollToCaret(ScrollType.MAKE_VISIBLE)
     }
+  }
+
+  private fun calculateMarkAndQuery(jumpPerformed: Boolean): Pair<String?, String?> {
+    var mark: String? = null
+    var query: String? = null
+    if (jumpPerformed) {
+      val offset = editor.caretModel.offset
+      mark = tagger.getMarkByOffset(offset)
+      if (mark != null) {
+        (searchProcessor?.query as? SearchQuery.Literal)?.rawText?.let {
+          if (it.endsWith(mark)) {
+            query = it.dropLast(mark.length)
+          }
+        }
+      }
+    }
+    return Pair(mark, query)
   }
 
   @ExternalUsage

--- a/src/main/kotlin/org/acejump/session/SessionManager.kt
+++ b/src/main/kotlin/org/acejump/session/SessionManager.kt
@@ -35,8 +35,8 @@ object SessionManager {
    * Ends the active [Session] in the specified [Editor],
    * or does nothing if the [Editor] has no active session.
    */
-  fun end(editor: Editor) = sessions.remove(editor)?.dispose() ?: Unit
+  fun end(editor: Editor, jumpPerformed: Boolean) = sessions.remove(editor)?.dispose(jumpPerformed) ?: Unit
 
   private fun cleanup() = sessions.keys.filter { it.isDisposed }
-    .forEach { disposedEditor -> sessions.remove(disposedEditor)?.dispose() }
+    .forEach { disposedEditor -> sessions.remove(disposedEditor)?.dispose(false) }
 }


### PR DESCRIPTION
Hi! I'd like to add some PRs to make AceJump more compatible with IdeaVim-EasyMotion.

First of all, for some commands in easymotion the caret jumps to the end of the query. AceJump doesn't support this mode, so for this case, I update the caret position in `finished` listener, but I don't know the length of the query.

This change passes a bit of information about the session results: query and selected mark.

So, in general, I'd like to know the length of the `query` in `finished` listener, so I'm open to discussions about other methods to approach this.

FYI: @chylex 