### PR TITLE
Allow defining jump mode with boundaries

### DIFF
--- a/src/main/kotlin/org/acejump/session/Session.kt
+++ b/src/main/kotlin/org/acejump/session/Session.kt
@@ -34,6 +34,8 @@ class Session(private val editor: Editor) {
   private val listeners: MutableList<AceJumpListener> =
     ContainerUtil.createLockFreeCopyOnWriteList()
 
+  private var boundaries: Boundaries = defaultBoundaries
+
   private companion object {
     private val defaultBoundaries
       get() = if (AceConfig.searchWholeFile) WHOLE_FILE else VISIBLE_ON_SCREEN
@@ -82,7 +84,7 @@ class Session(private val editor: Editor) {
         if (processor == null) {
           processor = SearchProcessor.fromChar(
             editor,
-            charTyped, defaultBoundaries
+            charTyped, boundaries
           ).also { searchProcessor = it }
         } else if (!processor.type(charTyped, tagger)) {
           return
@@ -197,6 +199,12 @@ class Session(private val editor: Editor) {
    * See [JumpModeTracker.toggle]
    */
   fun toggleJumpMode(newMode: JumpMode) {
+    jumpMode = jumpModeTracker.toggle(newMode)
+  }
+
+  @ExternalUsage
+  fun toggleJumpMode(newMode: JumpMode, boundaries: Boundaries) {
+    this.boundaries = this.boundaries.intersection(boundaries)
     jumpMode = jumpModeTracker.toggle(newMode)
   }
 

--- a/src/test/kotlin/ExternalUsageTest.kt
+++ b/src/test/kotlin/ExternalUsageTest.kt
@@ -1,7 +1,12 @@
+import com.intellij.openapi.editor.Editor
 import junit.framework.TestCase
-import org.acejump.boundaries.StandardBoundaries.*
-import org.acejump.search.Pattern.*
-import org.acejump.session.*
+import org.acejump.boundaries.Boundaries
+import org.acejump.boundaries.EditorOffsetCache
+import org.acejump.boundaries.StandardBoundaries.WHOLE_FILE
+import org.acejump.input.JumpMode
+import org.acejump.search.Pattern.ALL_WORDS
+import org.acejump.session.AceJumpListener
+import org.acejump.session.SessionManager
 import org.acejump.test.util.BaseTest
 
 /**
@@ -45,5 +50,25 @@ class ExternalUsageTest: BaseTest() {
       .startRegexSearch("[aeiou]+", WHOLE_FILE)
 
     TestCase.assertEquals(8, session.tags.size)
+  }
+
+  fun `test external jump with bounds`() {
+    makeEditor("test word and word usage")
+
+    SessionManager.start(myFixture.editor)
+      .toggleJumpMode(JumpMode.JUMP, object : Boundaries {
+        override fun getOffsetRange(editor: Editor, cache: EditorOffsetCache): IntRange {
+          return 14..18
+        }
+
+        override fun isOffsetInside(editor: Editor, offset: Int, cache: EditorOffsetCache): Boolean {
+          return offset in 14..18
+        }
+      })
+
+    typeAndWaitForResults("word")
+
+    TestCase.assertEquals(1, session.tags.size)
+    TestCase.assertEquals(14, session.tags.single().value)
   }
 }


### PR DESCRIPTION
Another PR!
regex search allows you to define custom boundaries, but a regular jump not. Here is a change that adds a version of `toggleJumpMode` with `boundaries` parameter.