### PR TITLE
Implement jumping across splitters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 3.8.0
+- Allow jumping between splitters in the editor, [#371](https://github.com/acejump/AceJump/pull/371)
+
 ## 3.7.1
 - Fix settings display issue, [#363](https://github.com/acejump/AceJump/issues/363)
 - Update AceJump extension API to include tag information, [#357](https://github.com/acejump/AceJump/pull/357)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ tasks {
 }
 
 changelog {
-  version = "3.7.1"
+  version = "3.8.0"
   path = "${project.projectDir}/CHANGES.md"
   header = closure { "[${project.version}] - ${date()}" }
   itemPrefix = "-"
@@ -63,4 +63,4 @@ intellij {
 }
 
 group = "org.acejump"
-version = "3.7.1"
+version = "3.8.0"

--- a/src/main/kotlin/org/acejump/action/AceAction.kt
+++ b/src/main/kotlin/org/acejump/action/AceAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.util.IncorrectOperationException
 import org.acejump.boundaries.Boundaries
 import org.acejump.boundaries.StandardBoundaries.*
 import org.acejump.input.JumpMode
@@ -27,10 +28,14 @@ sealed class AceAction: DumbAwareAction() {
     val project = e.project
   
     if (project != null) {
-      val openEditors = FileEditorManagerEx.getInstanceEx(project).splitters.selectedEditors
-        .mapNotNull { (it as? TextEditor)?.editor }
-        .sortedBy { if (it === editor) 0 else 1 }
-      invoke(SessionManager.start(editor, openEditors))
+      try {
+        val openEditors = FileEditorManagerEx.getInstanceEx(project).splitters.selectedEditors
+          .mapNotNull { (it as? TextEditor)?.editor }
+          .sortedBy { if (it === editor) 0 else 1 }
+        invoke(SessionManager.start(editor, openEditors))
+      } catch (e: IncorrectOperationException) {
+        invoke(SessionManager.start(editor))
+      }
     }
     else {
       invoke(SessionManager.start(editor))

--- a/src/main/kotlin/org/acejump/action/AceAction.kt
+++ b/src/main/kotlin/org/acejump/action/AceAction.kt
@@ -2,9 +2,10 @@ package org.acejump.action
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR
+import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.project.DumbAwareAction
 import org.acejump.boundaries.Boundaries
-import org.acejump.boundaries.StandardBoundaries
 import org.acejump.boundaries.StandardBoundaries.*
 import org.acejump.input.JumpMode
 import org.acejump.input.JumpMode.*
@@ -21,9 +22,21 @@ sealed class AceAction: DumbAwareAction() {
     action.presentation.isEnabled = action.getData(EDITOR) != null
   }
 
-  final override fun actionPerformed(e: AnActionEvent) =
-    e.getData(EDITOR)?.let { invoke(SessionManager.start(it)) } ?: Unit
-
+  final override fun actionPerformed(e: AnActionEvent) {
+    val editor = e.getData(EDITOR) ?: return
+    val project = e.project
+  
+    if (project != null) {
+      val openEditors = FileEditorManagerEx.getInstanceEx(project).splitters.selectedEditors
+        .mapNotNull { (it as? TextEditor)?.editor }
+        .sortedBy { if (it === editor) 0 else 1 }
+      invoke(SessionManager.start(editor, openEditors))
+    }
+    else {
+      invoke(SessionManager.start(editor))
+    }
+  }
+  
   abstract operator fun invoke(session: Session)
 
   /**

--- a/src/main/kotlin/org/acejump/action/TagJumper.kt
+++ b/src/main/kotlin/org/acejump/action/TagJumper.kt
@@ -9,6 +9,8 @@ import com.intellij.openapi.command.UndoConfirmationPolicy
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.actionSystem.DocCommandGroupId
+import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.fileEditor.ex.IdeDocumentHistory
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.playback.commands.ActionCommand
@@ -16,15 +18,19 @@ import org.acejump.*
 import org.acejump.input.JumpMode
 import org.acejump.input.JumpMode.*
 import org.acejump.search.SearchProcessor
+import org.acejump.search.Tag
 
 /**
  * Performs [JumpMode] navigation and actions.
  */
-internal class TagJumper(private val editor: Editor, private val mode: JumpMode, private val searchProcessor: SearchProcessor?) {
+internal class TagJumper(private val mode: JumpMode, private val searchProcessor: SearchProcessor?) {
   /**
    * Moves caret to a specific offset in the editor according to the positioning and selection rules of the current [JumpMode].
    */
-  fun visit(offset: Int) {
+  fun visit(tag: Tag) {
+    val editor = tag.editor
+    val offset = tag.offset
+    
     if (mode === JUMP_END || mode === TARGET) {
       val chars = editor.immutableText
       val matchingChars = searchProcessor?.let { chars.countMatchingCharacters(offset, it.query.rawText) } ?: 0
@@ -50,17 +56,18 @@ internal class TagJumper(private val editor: Editor, private val mode: JumpMode,
    * Updates caret and selection by [visit]ing a specific offset in the editor, and applying session-finalizing [JumpMode] actions such as
    * using the Go To Declaration action, or selecting text between caret and target offset/word if Shift was held during the jump.
    */
-  fun jump(offset: Int, shiftMode: Boolean) {
+  fun jump(tag: Tag, shiftMode: Boolean, isCrossEditor: Boolean) {
+    val editor = tag.editor
     val oldOffset = editor.caretModel.offset
 
-    visit(offset)
+    visit(tag)
 
     if (mode === DEFINE) {
       performAction(if (shiftMode) GotoTypeDeclarationAction() else GotoDeclarationAction())
       return
     }
 
-    if (shiftMode) {
+    if (shiftMode && !isCrossEditor) {
       val newOffset = editor.caretModel.offset
 
       if (mode === TARGET) {
@@ -78,6 +85,7 @@ internal class TagJumper(private val editor: Editor, private val mode: JumpMode,
 
   private companion object {
     private fun moveCaretTo(editor: Editor, offset: Int) = with(editor) {
+      ensureEditorFocused(this)
       project?.let { addCurrentPositionToHistory(it, document) }
       selectionModel.removeSelection(true)
       caretModel.moveToOffset(offset)
@@ -87,6 +95,16 @@ internal class TagJumper(private val editor: Editor, private val mode: JumpMode,
       selectionModel.removeSelection(true)
       selectionModel.setSelection(fromOffset, toOffset)
       caretModel.moveToOffset(toOffset)
+    }
+  
+    private fun ensureEditorFocused(editor: Editor) {
+      val project = editor.project ?: return
+      val fem = FileEditorManagerEx.getInstanceEx(project)
+    
+      val window = fem.windows.firstOrNull { (it.selectedEditor?.selectedWithProvider?.fileEditor as? TextEditor)?.editor === editor }
+      if (window != null && window !== fem.currentWindow) {
+        fem.currentWindow = window
+      }
     }
 
     private fun addCurrentPositionToHistory(project: Project, document: Document) {

--- a/src/main/kotlin/org/acejump/search/SearchProcessor.kt
+++ b/src/main/kotlin/org/acejump/search/SearchProcessor.kt
@@ -12,41 +12,55 @@ import org.acejump.matchesAt
  * previous results when the user [type]s a character.
  */
 internal class SearchProcessor private constructor(
-  private val editor: Editor, query: SearchQuery, boundaries: Boundaries
+  private val editors: List<Editor>,
+  query: SearchQuery,
+  results: MutableMap<Editor, IntArrayList>
 ) {
   companion object {
-    fun fromChar(editor: Editor, char: Char, boundaries: Boundaries) =
-      SearchProcessor(editor, SearchQuery.Literal(char.toString()), boundaries)
+    fun fromChar(editors: List<Editor>, char: Char, boundaries: Boundaries) =
+      SearchProcessor(editors, SearchQuery.Literal(char.toString()), boundaries)
 
-    fun fromRegex(editor: Editor, pattern: String, boundaries: Boundaries) =
-      SearchProcessor(editor, SearchQuery.RegularExpression(pattern), boundaries)
+    fun fromRegex(editors: List<Editor>, pattern: String, boundaries: Boundaries) =
+      SearchProcessor(editors, SearchQuery.RegularExpression(pattern), boundaries)
   }
-
-  var query = query
-    private set
-
-  var results = IntArrayList(0)
-    internal set
-
-  init {
-    query.toRegex()?.let { regex ->
-      val offsetRange = boundaries.getOffsetRange(editor)
-      var result = regex.find(editor.immutableText, offsetRange.first)
-
-      while (result != null) {
-        // For some reason regex matches can be out of bounds, but
-        // boundary check prevents an exception.
-        val index = result.range.first
-        val highlightEnd = index + query.getHighlightLength("", index)
-
-        if (highlightEnd > offsetRange.last) break
-        else if (boundaries.isOffsetInside(editor, index)) results.add(index)
-
-        result = result.next()
+  
+  private constructor(editors: List<Editor>, query: SearchQuery, boundaries: Boundaries) : this(editors, query, mutableMapOf()) {
+    val regex = query.toRegex()
+    
+    if (regex != null) {
+      for (editor in editors) {
+        val offsets = IntArrayList()
+        
+        val offsetRange = boundaries.getOffsetRange(editor)
+        var result = regex.find(editor.immutableText, offsetRange.first)
+        
+        while (result != null) {
+          // For some reason regex matches can be out of bounds, but
+          // boundary check prevents an exception.
+          val index = result.range.first
+          val highlightEnd = index + query.getHighlightLength("", index)
+          
+          if (highlightEnd > offsetRange.last) {
+            break
+          }
+          else if (boundaries.isOffsetInside(editor, index)) {
+            offsets.add(index)
+          }
+          
+          result = result.next()
+        }
+        
+        results[editor] = offsets
       }
     }
   }
-
+  
+  var query = query
+    private set
+  
+  var results = results
+    private set
+  
   /**
    * Appends a character to the search query and removes all search results
    * that no longer match the query. If the last typed character transitioned
@@ -56,18 +70,16 @@ internal class SearchProcessor private constructor(
    */
   fun type(char: Char, tagger: Tagger): Boolean {
     val newQuery = query.rawText + char
-    val chars = editor.immutableText
     val canMatchTag = tagger.canQueryMatchAnyTag(newQuery)
-
+    
     // If the typed character is not compatible with any existing tag or as
     // a continuation of any previous occurrence, reject the query change
     // and return false to indicate that nothing else should happen.
-
-    if (
-      newQuery.length > 1 && !canMatchTag &&
-      results.none { chars.matchesAt(it, newQuery, ignoreCase = true) }
-    ) return false
-
+    
+    if (newQuery.length > 1 && !canMatchTag && !isContinuation(newQuery)) {
+      return false
+    }
+  
     // If the typed character transitioned the search query from a non-word
     // to a word, and the typed character does not belong to an existing tag,
     // we basically restart the search at the beginning of every new word,
@@ -75,23 +87,25 @@ internal class SearchProcessor private constructor(
     // afterwards. Although this causes tags to change, it is one solution for
     // conflicts between tag characters and search query characters, and moving
     // searches across word boundaries during search should be fairly uncommon.
-
-    if (!canMatchTag && newQuery.length >= 2 &&
-      !newQuery[newQuery.length - 2].isWordPart &&
-      char.isWordPart
-    ) {
+  
+    if (!canMatchTag && newQuery.length >= 2 && !newQuery[newQuery.length - 2].isWordPart && char.isWordPart) {
       query = SearchQuery.Literal(char.toString())
       tagger.unmark()
-
-      val iter = results.iterator()
-      while (iter.hasNext()) {
-        val movedOffset = iter.nextInt() + newQuery.length - 1
-
-        if (movedOffset < chars.length &&
-          chars[movedOffset].equals(char, ignoreCase = true)
-        )
-          iter.set(movedOffset)
-        else iter.remove()
+      
+      for ((editor, offsets) in results) {
+        val chars = editor.immutableText
+        val iter = offsets.iterator()
+        
+        while (iter.hasNext()) {
+          val movedOffset = iter.nextInt() + newQuery.length - 1
+          
+          if (movedOffset < chars.length && chars[movedOffset].equals(char, ignoreCase = true)) {
+            iter.set(movedOffset)
+          }
+          else {
+            iter.remove()
+          }
+        }
       }
     } else {
       removeObsoleteResults(newQuery, tagger)
@@ -100,7 +114,21 @@ internal class SearchProcessor private constructor(
 
     return true
   }
-
+  
+  /**
+   * Returns true if the new query is a continuation of any remaining search query.
+   */
+  private fun isContinuation(newQuery: String): Boolean {
+    for ((editor, offsets) in results) {
+      val chars = editor.immutableText
+      if (offsets.any { chars.matchesAt(it, newQuery, ignoreCase = true) }) {
+        return true
+      }
+    }
+    
+    return false
+  }
+  
   /**
    * After updating the query, removes all results that no longer match
    * the search query.
@@ -109,23 +137,25 @@ internal class SearchProcessor private constructor(
     val lastCharOffset = newQuery.lastIndex
     val lastChar = newQuery[lastCharOffset]
     val ignoreCase = newQuery[0].isLowerCase()
-    val chars = editor.immutableText
-
-    val remaining = IntArrayList()
-    val iter = results.iterator()
-
-    while (iter.hasNext()) {
-      val offset = iter.nextInt()
-      val endOffset = offset + lastCharOffset
-      val lastTypedCharMatches = endOffset < chars.length &&
-        chars[endOffset].equals(lastChar, ignoreCase)
-
-      if (lastTypedCharMatches ||
-        tagger.isQueryCompatibleWithTagAt(newQuery, offset)) {
-        remaining.add(offset)
+  
+    for ((editor, offsets) in results.entries.toList()) {
+      val chars = editor.immutableText
+      val remaining = IntArrayList()
+      val iter = offsets.iterator()
+    
+      while (iter.hasNext()) {
+        val offset = iter.nextInt()
+        val endOffset = offset + lastCharOffset
+        val lastTypedCharMatches = endOffset < chars.length &&
+          chars[endOffset].equals(lastChar, ignoreCase)
+      
+        if (lastTypedCharMatches ||
+          tagger.isQueryCompatibleWithTagAt(newQuery, Tag(editor, offset))) {
+          remaining.add(offset)
+        }
       }
+    
+      results[editor] = remaining
     }
-
-    results = remaining
   }
 }

--- a/src/main/kotlin/org/acejump/search/Solver.kt
+++ b/src/main/kotlin/org/acejump/search/Solver.kt
@@ -1,20 +1,16 @@
 package org.acejump.search
 
 import com.intellij.openapi.editor.Editor
-import it.unimi.dsi.fastutil.ints.*
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
+import it.unimi.dsi.fastutil.ints.IntList
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet
 import org.acejump.boundaries.EditorOffsetCache
-import org.acejump.boundaries.StandardBoundaries
 import org.acejump.boundaries.StandardBoundaries.VISIBLE_ON_SCREEN
 import org.acejump.config.AceConfig
 import org.acejump.immutableText
 import org.acejump.input.KeyLayoutCache
 import org.acejump.isWordPart
-import org.acejump.session.Session
 import org.acejump.wordEndPlus
 import java.util.*
-import kotlin.collections.HashMap
-import kotlin.collections.HashSet
 import kotlin.math.max
 
 /*
@@ -55,49 +51,59 @@ import kotlin.math.max
  */
 
 internal class Solver private constructor(
-  private val editor: Editor,
+  private val editorPriority: List<Editor>,
   private val queryLength: Int,
-  private val newResults: IntList,
-  private val allResults: IntList
+  private val newResults: Map<Editor, IntList>,
+  private val allResults: Map<Editor, IntList>
 ) {
   companion object {
     fun solve(
-      editor: Editor, query: SearchQuery,
-      newResults: IntList, allResults: IntList,
-      tags: List<String>, cache: EditorOffsetCache
-    ): Map<String, Int> =
-      Solver(editor, max(1, query.rawText.length), newResults, allResults)
-        .map(tags, cache)
+      editorPriority: List<Editor>,
+      query: SearchQuery,
+      newResults: Map<Editor, IntList>,
+      allResults: Map<Editor, IntList>,
+      tags: List<String>,
+      caches: Map<Editor, EditorOffsetCache>
+    ): Map<String, Tag> =
+      Solver(editorPriority, max(1, query.rawText.length), newResults, allResults)
+        .map(tags, caches)
   }
 
-  private var newTags = Object2IntOpenHashMap<String>(KeyLayoutCache.allPossibleTags.size)
-  private val newTagIndices = IntOpenHashSet()
+  private var newTags = HashMap<String, Tag>(KeyLayoutCache.allPossibleTags.size)
+  private val newTagIndices = newResults.keys.associateWith { IntOpenHashSet() }
 
   private var allWordFragments =
-    HashSet<String>(allResults.size).apply {
-      val iter = allResults.iterator()
-      while (iter.hasNext()) forEachWordFragment(iter.nextInt()) { add(it) }
+    HashSet<String>(allResults.values.sumBy(IntList::size)).apply {
+      for ((editor, offsets) in allResults) {
+        val iter = offsets.iterator()
+        while (iter.hasNext()) forEachWordFragment(editor, iter.nextInt()) { add(it) }
+      }
     }
 
-  fun map(availableTags: List<String>, cache: EditorOffsetCache): Map<String, Int> {
-    val eligibleSitesByTag = HashMap<String, IntList>(100)
+  fun map(availableTags: List<String>, caches: Map<Editor, EditorOffsetCache>): Map<String, Tag> {
+    val eligibleSitesByTag = HashMap<String, MutableList<Tag>>(100)
     val tagsByFirstLetter = availableTags.groupBy { it[0] }
-
-    val iter = newResults.iterator()
-    while (iter.hasNext()) {
-      val site = iter.nextInt()
-
-      for ((firstLetter, tags) in tagsByFirstLetter.entries)
-        if (canTagBeginWithChar(site, firstLetter))
-          for (tag in tags)
-            eligibleSitesByTag.getOrPut(tag) { IntArrayList(10) }.add(site)
+    
+    for ((editor, offsets) in newResults) {
+      val iter = offsets.iterator()
+      while (iter.hasNext()) {
+        val site = iter.nextInt()
+        
+        for ((firstLetter, tags) in tagsByFirstLetter.entries) {
+          if (canTagBeginWithChar(editor, site, firstLetter)) {
+            for (tag in tags) {
+              eligibleSitesByTag.getOrPut(tag, ::mutableListOf).add(Tag(editor, site))
+            }
+          }
+        }
+      }
     }
-
-    val matchingSites = HashMap<IntList, IntArray>()
+    
+    val matchingSites = HashMap<MutableList<Tag>, MutableList<Tag>>()
     // Keys are guaranteed to be from a single collection.
-    val matchingSitesAsArrays = IdentityHashMap<String, IntArray>()
-
-    val siteOrder = siteOrder(cache)
+    val matchingSitesAsArrays = IdentityHashMap<String, MutableList<Tag>>()
+    
+    val siteOrder = siteOrder(caches)
     val tagOrder = KeyLayoutCache.tagOrder
       .thenComparingInt { eligibleSitesByTag.getValue(it).size }
       .thenBy(AceConfig.layout.priority(String::last))
@@ -106,16 +112,17 @@ internal class Solver private constructor(
       sortWith(tagOrder)
     }
 
-    for ((key, value) in eligibleSitesByTag.entries) {
-      matchingSitesAsArrays[key] = matchingSites.getOrPut(value) {
-        value.toIntArray().apply { IntArrays.mergeSort(this, siteOrder) }
+    for ((mark, tags) in eligibleSitesByTag.entries) {
+      matchingSitesAsArrays[mark] = matchingSites.getOrPut(tags) {
+        tags.toMutableList().apply { sortWith(siteOrder) }
       }
     }
 
     var totalAssigned = 0
-
+    val totalResults = newResults.values.sumBy(IntList::size)
+    
     for (tag in sortedTags) {
-      if (totalAssigned == newResults.size) {
+      if (totalAssigned == totalResults) {
         break
       }
 
@@ -127,51 +134,56 @@ internal class Solver private constructor(
     return newTags
   }
 
-  private fun tryToAssignTag(tag: String, sites: IntArray): Boolean {
-    if (newTags.containsKey(tag)) return false
+  private fun tryToAssignTag(mark: String, tags: List<Tag>): Boolean {
+    if (newTags.containsKey(mark)) return false
 
-    val index = sites.firstOrNull { it !in newTagIndices } ?: return false
-
+    val tag = tags.firstOrNull { it.offset !in newTagIndices.getValue(it.editor) } ?: return false
     @Suppress("ReplacePutWithAssignment")
-    newTags.put(tag, index)
-    newTagIndices.add(index)
+    newTags.put(mark, tag)
+    newTagIndices.getValue(tag.editor).add(tag.offset)
     return true
   }
 
-  private fun siteOrder(cache: EditorOffsetCache) = IntComparator { a, b ->
-    val aIsVisible = VISIBLE_ON_SCREEN.isOffsetInside(editor, a, cache)
-    val bIsVisible = VISIBLE_ON_SCREEN.isOffsetInside(editor, b, cache)
-
+  private fun siteOrder(caches: Map<Editor, EditorOffsetCache>) = Comparator<Tag> { a, b ->
+    val aEditor = a.editor
+    val bEditor = b.editor
+  
+    if (aEditor !== bEditor) {
+      val aEditorIndex = editorPriority.indexOf(aEditor)
+      val bEditorIndex = editorPriority.indexOf(bEditor)
+      // For multiple editors, prioritize them based on the provided order.
+      return@Comparator if (aEditorIndex < bEditorIndex) -1 else 1
+    }
+  
+    val aIsVisible = VISIBLE_ON_SCREEN.isOffsetInside(aEditor, a.offset, caches.getValue(aEditor))
+    val bIsVisible = VISIBLE_ON_SCREEN.isOffsetInside(bEditor, b.offset, caches.getValue(bEditor))
     if (aIsVisible != bIsVisible) {
       // Sites in immediate view should come first.
-      return@IntComparator if (aIsVisible) -1 else 1
+      return@Comparator if (aIsVisible) -1 else 1
     }
-
-    val chars = editor.immutableText
-    val aIsNotWordStart = chars[max(0, a - 1)].isWordPart
-    val bIsNotWordStart = chars[max(0, b - 1)].isWordPart
-
+  
+    val aIsNotWordStart = aEditor.immutableText[max(0, a.offset - 1)].isWordPart
+    val bIsNotWordStart = bEditor.immutableText[max(0, b.offset - 1)].isWordPart
     if (aIsNotWordStart != bIsNotWordStart) {
       // Ensure that the first letter of a word is prioritized for tagging.
-      return@IntComparator if (bIsNotWordStart) -1 else 1
+      return@Comparator if (bIsNotWordStart) -1 else 1
     }
-
+  
     when {
-      a < b -> -1
-      a > b -> 1
-      else -> 0
+      a.offset < b.offset -> -1
+      a.offset > b.offset -> 1
+      else                -> 0
     }
   }
 
-  private fun canTagBeginWithChar(site: Int, char: Char): Boolean {
+  private fun canTagBeginWithChar(editor: Editor, site: Int, char: Char): Boolean {
     if (char.toString() in allWordFragments) return false
 
-    forEachWordFragment(site) { if (it + char in allWordFragments) return false }
-
+    forEachWordFragment(editor, site) { if (it + char in allWordFragments) return false }
     return true
   }
 
-  private inline fun forEachWordFragment(site: Int, callback: (String) -> Unit) {
+  private inline fun forEachWordFragment(editor: Editor, site: Int, callback: (String) -> Unit) {
     val chars = editor.immutableText
     val left = max(0, site + queryLength - 1)
     val right = chars.wordEndPlus(site)

--- a/src/main/kotlin/org/acejump/search/Tag.kt
+++ b/src/main/kotlin/org/acejump/search/Tag.kt
@@ -1,0 +1,5 @@
+package org.acejump.search
+
+import com.intellij.openapi.editor.Editor
+
+data class Tag(val editor: Editor, val offset: Int)

--- a/src/main/kotlin/org/acejump/search/TaggingResult.kt
+++ b/src/main/kotlin/org/acejump/search/TaggingResult.kt
@@ -1,8 +1,9 @@
 package org.acejump.search
 
-import org.acejump.view.Tag
+import com.intellij.openapi.editor.Editor
+import org.acejump.view.TagMarker
 
 sealed class TaggingResult {
-  class Jump(val query: String, val tag: String, val offset: Int): TaggingResult()
-  class Mark(val tags: List<Tag>): TaggingResult()
+  class Jump(val query: String, val mark: String, val tag: Tag): TaggingResult()
+  class Mark(val markers: MutableMap<Editor, Collection<TagMarker>>): TaggingResult()
 }

--- a/src/main/kotlin/org/acejump/session/Session.kt
+++ b/src/main/kotlin/org/acejump/session/Session.kt
@@ -7,12 +7,14 @@ import com.intellij.openapi.editor.actionSystem.TypedActionHandler
 import com.intellij.openapi.editor.colors.EditorColors.CARET_COLOR
 import com.intellij.util.containers.ContainerUtil
 import it.unimi.dsi.fastutil.ints.IntArrayList
-import org.acejump.*
+import org.acejump.ExternalUsage
 import org.acejump.action.TagJumper
 import org.acejump.action.TagVisitor
 import org.acejump.boundaries.Boundaries
 import org.acejump.boundaries.EditorOffsetCache
-import org.acejump.boundaries.StandardBoundaries.*
+import org.acejump.boundaries.StandardBoundaries.VISIBLE_ON_SCREEN
+import org.acejump.boundaries.StandardBoundaries.WHOLE_FILE
+import org.acejump.clone
 import org.acejump.config.AceConfig
 import org.acejump.input.EditorKeyListener
 import org.acejump.input.JumpMode
@@ -27,9 +29,9 @@ import org.acejump.view.TextHighlighter
 import java.util.*
 
 /**
- * Manages an AceJump session for a single [Editor].
+ * Manages an AceJump session for one or more [Editor]s.
  */
-class Session(private val editor: Editor) {
+class Session(private val mainEditor: Editor, private val jumpEditors: List<Editor>) {
   private val listeners: MutableList<AceJumpListener> =
     ContainerUtil.createLockFreeCopyOnWriteList()
 
@@ -40,7 +42,7 @@ class Session(private val editor: Editor) {
       get() = if (AceConfig.searchWholeFile) WHOLE_FILE else VISIBLE_ON_SCREEN
   }
 
-  private val originalSettings = EditorSettings.setup(editor)
+  private val originalSettings = EditorSettings.setup(mainEditor)
 
   private val jumpModeTracker = JumpModeTracker()
   private var jumpMode = JumpMode.DISABLED
@@ -51,22 +53,22 @@ class Session(private val editor: Editor) {
         end()
       } else {
         searchProcessor?.let { textHighlighter.render(it.results, it.query, jumpMode) }
-        editor.colorsScheme.setColor(CARET_COLOR, value.caretColor)
-        editor.contentComponent.repaint()
+        mainEditor.colorsScheme.setColor(CARET_COLOR, value.caretColor)
+        mainEditor.contentComponent.repaint()
       }
     }
 
   private var searchProcessor: SearchProcessor? = null
-  private var tagger = Tagger(editor)
+  private var tagger = Tagger(jumpEditors)
 
   private val tagJumper
-    get() = TagJumper(editor, jumpMode, searchProcessor)
+    get() = TagJumper(jumpMode, searchProcessor)
 
   private val tagVisitor
-    get() = searchProcessor?.let { TagVisitor(editor, it, tagJumper) }
-
-  private val textHighlighter = TextHighlighter(editor)
-  private val tagCanvas = TagCanvas(editor)
+    get() = searchProcessor?.let { TagVisitor(mainEditor, it, tagJumper) }
+  
+  private val textHighlighter = TextHighlighter()
+  private val tagCanvases = jumpEditors.associateWith(::TagCanvas)
 
   @ExternalUsage
   val tags
@@ -75,15 +77,14 @@ class Session(private val editor: Editor) {
   init {
     KeyLayoutCache.ensureInitialized(AceConfig.settings)
 
-    EditorKeyListener.attach(editor, object: TypedActionHandler {
+    EditorKeyListener.attach(mainEditor, object: TypedActionHandler {
       override fun execute(editor: Editor, charTyped: Char, context: DataContext) {
         var processor = searchProcessor
         val hadTags = tagger.hasTags
 
         if (processor == null) {
           processor = SearchProcessor.fromChar(
-            editor,
-            charTyped, boundaries
+            jumpEditors, charTyped, boundaries
           ).also { searchProcessor = it }
         } else if (!processor.type(charTyped, tagger)) {
           return
@@ -123,34 +124,51 @@ class Session(private val editor: Editor) {
 
     when (val result = tagger.markOrJump(query, results.clone())) {
       is TaggingResult.Jump -> {
-        tagJumper.jump(result.offset, shiftMode)
-        tagCanvas.removeMarkers()
+        tagJumper.jump(result.tag, shiftMode, isCrossEditor = mainEditor !== result.tag.editor)
+        tagCanvases.values.forEach(TagCanvas::removeMarkers)
         end(result)
       }
 
       is TaggingResult.Mark -> {
-        val tags = result.tags
-        tagCanvas.setMarkers(tags)
-
-        val cache = EditorOffsetCache.new()
-        val boundaries = VISIBLE_ON_SCREEN
-
-        if (tags.none {
-            boundaries.isOffsetInside(editor, it.offsetL, cache) ||
-              boundaries.isOffsetInside(editor, it.offsetR, cache)
-          }) tagVisitor?.scrollToClosest()
+        val markers = result.markers
+        
+        for ((editor, canvas) in tagCanvases) {
+          canvas.setMarkers(markers[editor].orEmpty())
+        }
+        
+        if (jumpEditors.all { editor ->
+            val cache = EditorOffsetCache.new()
+            markers[editor].let { it == null || it.none { marker ->
+              VISIBLE_ON_SCREEN.isOffsetInside(editor, marker.offsetL, cache) ||
+              VISIBLE_ON_SCREEN.isOffsetInside(editor, marker.offsetR, cache) } }
+        }) {
+          tagVisitor?.scrollToClosest()
+        }
       }
     }
   }
 
   @ExternalUsage
   fun markResults(resultsToMark: SortedSet<Int>) {
-    tagger = Tagger(editor)
-    tagCanvas.setMarkers(emptyList())
-
-    val processor = SearchProcessor.fromRegex(editor, "", defaultBoundaries)
-      .apply { results = IntArrayList(resultsToMark) }
-
+    val jumpEditor = jumpEditors.singleOrNull() ?: return
+    markResults(mapOf(jumpEditor to resultsToMark))
+  }
+  
+  @ExternalUsage
+  fun markResults(resultsToMark: Map<Editor, Collection<Int>>) {
+    tagger = Tagger(jumpEditors)
+    tagCanvases.values.forEach { it.setMarkers(emptyList()) }
+  
+    val processor = SearchProcessor.fromRegex(jumpEditors, "", defaultBoundaries)
+      .apply {
+        results.clear()
+        for ((editor, offsets) in resultsToMark) {
+          if (editor in jumpEditors) {
+            results[editor] = IntArrayList(offsets)
+          }
+        }
+      }
+  
     updateSearch(processor, markImmediately = true)
   }
 
@@ -161,11 +179,11 @@ class Session(private val editor: Editor) {
 
   @ExternalUsage
   fun startRegexSearch(pattern: String, boundaries: Boundaries) {
-    tagger = Tagger(editor)
-    tagCanvas.setMarkers(emptyList())
+    tagger = Tagger(jumpEditors)
+    tagCanvases.values.forEach { it.setMarkers(emptyList()) }
 
     val processor = SearchProcessor.fromRegex(
-      editor, pattern,
+      jumpEditors, pattern,
       boundaries.intersection(defaultBoundaries)
     ).also { searchProcessor = it }
     updateSearch(processor, markImmediately = true)
@@ -223,16 +241,16 @@ class Session(private val editor: Editor) {
    * Ends this session.
    */
   fun end(taggingResult: TaggingResult? = null) =
-    SessionManager.end(editor, taggingResult)
+    SessionManager.end(mainEditor, taggingResult)
 
   /**
    * Clears any currently active search, tags, and highlights.
    * Does not reset [JumpMode].
    */
   fun restart() {
-    tagger = Tagger(editor)
+    tagger = Tagger(jumpEditors)
     searchProcessor = null
-    tagCanvas.removeMarkers()
+    tagCanvases.values.forEach(TagCanvas::removeMarkers)
     textHighlighter.reset()
   }
 
@@ -241,20 +259,24 @@ class Session(private val editor: Editor) {
    * successfully ended session.
    */
   internal fun dispose(taggingResult: TaggingResult?) {
-    tagger = Tagger(editor)
-    EditorKeyListener.detach(editor)
-    tagCanvas.unbind()
+    tagger = Tagger(jumpEditors)
+    EditorKeyListener.detach(mainEditor)
+    tagCanvases.values.forEach(TagCanvas::unbind)
     textHighlighter.reset()
-    EditorCache.invalidate()
 
-    val (tag, query) = (taggingResult as TaggingResult.Jump?)
-      .let { it?.tag to it?.query }
-    listeners.forEach { it.finished(tag, query) }
+    val jumpResult = taggingResult as? TaggingResult.Jump
+    val mark = jumpResult?.mark
+    val query = jumpResult?.query
+    listeners.forEach { it.finished(mark, query) }
 
-    if (!editor.isDisposed) {
-      originalSettings.restore(editor)
-      editor.colorsScheme.setColor(CARET_COLOR, JumpMode.DISABLED.caretColor)
-      editor.scrollingModel.scrollToCaret(ScrollType.MAKE_VISIBLE)
+    if (!mainEditor.isDisposed) {
+      originalSettings.restore(mainEditor)
+      mainEditor.colorsScheme.setColor(CARET_COLOR, JumpMode.DISABLED.caretColor)
+    }
+
+    val focusedEditor = jumpResult?.tag?.editor ?: mainEditor
+    if (!focusedEditor.isDisposed) {
+      focusedEditor.scrollingModel.scrollToCaret(ScrollType.MAKE_VISIBLE)
     }
   }
 

--- a/src/main/kotlin/org/acejump/session/SessionManager.kt
+++ b/src/main/kotlin/org/acejump/session/SessionManager.kt
@@ -23,9 +23,18 @@ object SessionManager {
    * Starts a new [Session], or returns an existing [Session]
    * if the specified [Editor] already has one.
    */
-  fun start(editor: Editor): Session =
-    sessions.getOrPut(editor) { cleanup(); Session(editor) }
+  fun start(editor: Editor): Session = start(editor, listOf(editor))
 
+  /**
+   * Starts a new multi-editor [Session], or returns an existing [Session] if the specified main [Editor] already has one.
+   * The [mainEditor] is used for typing the search query and tag.
+   * The [jumpEditors] are all editors that will be searched and tagged. The list is ordered so that editors earlier in the list will be
+   * prioritized for tagging in case of conflicts.
+   */
+  fun start(mainEditor: Editor, jumpEditors: List<Editor>): Session {
+    return sessions.getOrPut(mainEditor) { cleanup(); Session(mainEditor, jumpEditors) }
+  }
+  
   /**
    * Returns the active [Session] in the specified [Editor],
    * or null if the [Editor] has no active session.

--- a/src/main/kotlin/org/acejump/view/TagFont.kt
+++ b/src/main/kotlin/org/acejump/view/TagFont.kt
@@ -1,13 +1,13 @@
 package org.acejump.view
 
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.colors.EditorFontType
-import com.intellij.openapi.editor.colors.EditorFontType.*
+import com.intellij.openapi.editor.colors.EditorFontType.BOLD
+import com.intellij.openapi.editor.colors.EditorFontType.PLAIN
 import java.awt.Font
 import java.awt.FontMetrics
 
 /**
- * Stores font metrics for aligning and rendering [Tag]s.
+ * Stores font metrics for aligning and rendering [TagMarker]s.
  */
 class TagFont(editor: Editor) {
   val tagFont: Font = editor.colorsScheme.getFont(BOLD)

--- a/src/main/kotlin/org/acejump/view/TagMarker.kt
+++ b/src/main/kotlin/org/acejump/view/TagMarker.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.ui.ColorUtil
 import com.intellij.ui.scale.JBUIScale
 import org.acejump.boundaries.EditorOffsetCache
-import org.acejump.boundaries.StandardBoundaries.*
+import org.acejump.boundaries.StandardBoundaries.VISIBLE_ON_SCREEN
 import org.acejump.config.AceConfig
 import org.acejump.countMatchingCharacters
 import org.acejump.immutableText
@@ -17,7 +17,7 @@ import kotlin.math.max
 /**
  * Describes a 1 or 2 character shortcut that points to a specific character in the editor.
  */
-class Tag(
+class TagMarker(
   private val tag: String,
   val offsetL: Int,
   val offsetR: Int,
@@ -33,7 +33,7 @@ class Tag(
      * Creates a new tag, precomputing some information about the nearby characters to reduce rendering overhead. If the last typed
      * character ([literalQueryText]) matches the first [tag] character, only the second [tag] character is displayed.
      */
-    fun create(editor: Editor, tag: String, offset: Int, literalQueryText: String?): Tag {
+    fun create(editor: Editor, tag: String, offset: Int, literalQueryText: String?): TagMarker {
       val chars = editor.immutableText
       val matching = literalQueryText?.let { chars.countMatchingCharacters(offset, it) } ?: 0
       val hasSpaceRight = offset + 1 >= chars.length || chars[offset + 1].isWhitespace()
@@ -43,7 +43,7 @@ class Tag(
       else
         tag.toUpperCase()
 
-      return Tag(displayedTag, offset, offset + max(0, matching - 1), tag.length - displayedTag.length, hasSpaceRight)
+      return TagMarker(displayedTag, offset, offset + max(0, matching - 1), tag.length - displayedTag.length, hasSpaceRight)
     }
 
     /**

--- a/src/test/kotlin/ExternalUsageTest.kt
+++ b/src/test/kotlin/ExternalUsageTest.kt
@@ -2,11 +2,13 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.util.ui.UIUtil
 import junit.framework.TestCase
 import org.acejump.action.AceAction
-import org.acejump.boundaries.*
+import org.acejump.boundaries.Boundaries
+import org.acejump.boundaries.EditorOffsetCache
 import org.acejump.boundaries.StandardBoundaries.WHOLE_FILE
 import org.acejump.input.JumpMode
 import org.acejump.search.Pattern.ALL_WORDS
-import org.acejump.session.*
+import org.acejump.session.AceJumpListener
+import org.acejump.session.SessionManager
 import org.acejump.test.util.BaseTest
 
 /**
@@ -69,7 +71,7 @@ class ExternalUsageTest: BaseTest() {
     typeAndWaitForResults("word")
 
     TestCase.assertEquals(1, session.tags.size)
-    TestCase.assertEquals(14, session.tags.single().value)
+    TestCase.assertEquals(14, session.tags.single().value.offset)
   }
 
   fun `test listener query and mark`() {

--- a/src/test/kotlin/org/acejump/test/util/BaseTest.kt
+++ b/src/test/kotlin/org/acejump/test/util/BaseTest.kt
@@ -4,12 +4,12 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.IdeActions
 import com.intellij.openapi.fileTypes.PlainTextFileType
 import com.intellij.psi.PsiFile
-import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.testFramework.FileEditorManagerTestCase
 import com.intellij.util.ui.UIUtil
 import org.acejump.action.AceAction
 import org.acejump.session.SessionManager
 
-abstract class BaseTest: BasePlatformTestCase() {
+abstract class BaseTest: FileEditorManagerTestCase() {
   companion object {
     inline fun averageTimeWithWarmup(warmupRuns: Int, timedRuns: Int, action: () -> Long): Long {
       repeat(warmupRuns) { action() }
@@ -34,9 +34,12 @@ abstract class BaseTest: BasePlatformTestCase() {
     myFixture.configureByText(PlainTextFileType.INSTANCE, contents)
 
   fun resetEditor() {
-    takeAction(IdeActions.ACTION_EDITOR_ESCAPE)
-    UIUtil.dispatchAllInvocationEvents()
-    assertEmpty(myFixture.editor.markupModel.allHighlighters)
+    myFixture.editor?.let {
+      takeAction(IdeActions.ACTION_EDITOR_ESCAPE)
+      UIUtil.dispatchAllInvocationEvents()
+      assertEmpty(it.markupModel.allHighlighters)
+    }
+    myManager.closeAllFiles()
   }
 
   fun typeAndWaitForResults(string: String) {


### PR DESCRIPTION
#370

> Do you plan to disable auto-scrolling in split-screen sessions or do you think it makes sense to scroll multiple editors to the nearest available match?

For now I made it so only the main editor scrolls if none of the editors have any visible matches. Not sure if it'd be a better idea to scroll another editor if the main editor has no matches, and then allow cycling across splitters, what do you think?

> It might be a good idea to disable uppercase/shift selection when switching between editors, but allow it when jumping within the same editor.

Disabled shift for cross-editor jumping, but kept it for `TARGET` mode.

> Cycling with Enter/Shift enter also becomes tricky, not sure how you're planning to handle that.

Cycling is in main editor only, but it could be worth a try to make it so the last tag in the main editor cycles to the first tag in the next editor, and so on.

Note, since `@ExternalUsage fun markResults(resultsToMark: SortedSet<Int>)` only has a list of offsets, I made it so it only works if there is a single editor. When [IdeaVim-EasyMotion](https://github.com/AlexPl292/IdeaVim-EasyMotion) starts a session it only has one editor so it will continue to work. @AlexPl292 if you'd like to take advantage of this feature, I added
- `Session.markResults(resultsToMark: Map<Editor, Collection<Int>>)`
- `SessionManager.start(mainEditor: Editor, jumpEditors: List<Editor>)`

which lets you initiate a session with multiple editors, and then send markers per editor. An example of starting a session with all open editors is in [AceAction.kt](https://github.com/chylex/IntelliJ-AceJump/blob/12ae15c0f795385a652211f70dfe7b8dbbf4a705/src/main/kotlin/org/acejump/action/AceAction.kt#L30-L33). Note that `Collection<Int>` can be FastUtil's `IntArrayList` to avoid boxing.

Also, @breandan please run your autoformatter on it, I enabled edits by maintainers so you should be able to push it into the branch, and then I think I can squash and force-push into the branch to make sure formatting is correct in the first commit.