### PR TITLE
ensure editor focus also when using select function

### DIFF
--- a/src/main/kotlin/org/acejump/action/TagJumper.kt
+++ b/src/main/kotlin/org/acejump/action/TagJumper.kt
@@ -92,6 +92,7 @@ internal class TagJumper(private val mode: JumpMode, private val searchProcessor
     }
 
     private fun selectRange(editor: Editor, fromOffset: Int, toOffset: Int) = with(editor) {
+      ensureEditorFocused(this)
       selectionModel.removeSelection(true)
       selectionModel.setSelection(fromOffset, toOffset)
       caretModel.moveToOffset(toOffset)


### PR DESCRIPTION
Using target mode with multiple editors open would select tag in other editor but focus would remain in starting editor.
