### PR TITLE
prevent setting INHERITED_COLOR_MARKER as border color

### DIFF
--- a/src/main/kotlin/org/acejump/view/TextHighlighter.kt
+++ b/src/main/kotlin/org/acejump/view/TextHighlighter.kt
@@ -117,9 +117,13 @@ internal class TextHighlighter {
       panel.add(label1, BorderLayout.WEST)
       panel.add(label2, BorderLayout.CENTER)
       panel.add(label3, BorderLayout.EAST)
-      panel.border = BorderFactory.createLineBorder(jumpMode.caretColor)
 
-      panel.background = jumpMode.caretColor
+      if (jumpMode == JumpMode.DISABLED) {
+        panel.border = BorderFactory.createLineBorder(Color.BLACK)
+      } else {
+        panel.border = BorderFactory.createLineBorder(jumpMode.caretColor)
+      }
+
       panel.preferredSize = Dimension(it.contentComponent.width +
           label1.preferredSize.width, panel.preferredSize.height)
 


### PR DESCRIPTION
Panel background is not visible either way so it can also be removed.

fixes #376