### PR TITLE
Workaround tag misalignment on high DPI screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ The following individuals have significantly improved AceJump through their cont
 
 * [John Lindquist](https://github.com/johnlindquist) for creating AceJump and supporting it for many years.
 * [Breandan Considine](https://github.com/breandan) for maintaining the project and adding some new features.
-* [Daniel Chýlek](https://github.com/chylex) for numerous [performance optimizations](https://github.com/acejump/AceJump/pulls?q=is%3Apr+author%3Achylex), [bug fixes](https://github.com/acejump/AceJump/issues/348#issuecomment-739454920) and [refactoring](https://github.com/acejump/AceJump/pull/353).
+* [chylex](https://github.com/chylex) for numerous [performance optimizations](https://github.com/acejump/AceJump/pulls?
+* q=is%3Apr+author%3Achylex), [bug fixes](https://github.com/acejump/AceJump/issues/348#issuecomment-739454920) and [refactoring](https://github.com/acejump/AceJump/pull/353).
 * [Alex Plate](https://github.com/AlexPl292) for submitting [several PRs](https://github.com/acejump/AceJump/pulls?q=is%3Apr+author%3AAlexPl292).
 * [Sven Speckmaier](https://github.com/svensp) for [improving](https://github.com/acejump/AceJump/pull/214) search latency.
 * [Stefan Monnier](https://www.iro.umontreal.ca/~monnier/) for algorithmic advice and maintaining Emacs for several years.

--- a/src/main/kotlin/org/acejump/view/TagMarker.kt
+++ b/src/main/kotlin/org/acejump/view/TagMarker.kt
@@ -2,6 +2,7 @@ package org.acejump.view
 
 import com.intellij.openapi.editor.Editor
 import com.intellij.ui.ColorUtil
+import com.intellij.ui.JreHiDpiUtil
 import com.intellij.ui.scale.JBUIScale
 import org.acejump.boundaries.EditorOffsetCache
 import org.acejump.boundaries.StandardBoundaries.VISIBLE_ON_SCREEN
@@ -51,7 +52,16 @@ class TagMarker(
      */
     private fun drawHighlight(g: Graphics2D, rect: Rectangle, color: Color) {
       g.color = color
-      g.fillRoundRect(rect.x, rect.y, rect.width, rect.height + 1, ARC, ARC)
+      
+      // Workaround for misalignment on high DPI screens.
+      if (JreHiDpiUtil.isJreHiDPI(g)) {
+        g.translate(0.0, -0.5)
+        g.fillRoundRect(rect.x, rect.y, rect.width, rect.height + 1, ARC, ARC)
+        g.translate(0.0, 0.5)
+      }
+      else {
+        g.fillRoundRect(rect.x, rect.y, rect.width, rect.height + 1, ARC, ARC)
+      }
     }
 
     /**

--- a/src/main/kotlin/org/acejump/view/TextHighlighter.kt
+++ b/src/main/kotlin/org/acejump/view/TextHighlighter.kt
@@ -164,7 +164,7 @@ internal class TextHighlighter {
       val end = EditorOffsetCache.Uncached.offsetToXY(editor, endOffset)
 
       g.color = AceConfig.textHighlightColor
-      g.fillRect(start.x, start.y + 1, end.x - start.x, editor.lineHeight - 1)
+      g.fillRect(start.x, start.y, end.x - start.x, editor.lineHeight)
 
       g.color = AceConfig.tagBackgroundColor
       g.drawRect(start.x, start.y, end.x - start.x, editor.lineHeight)
@@ -213,7 +213,7 @@ internal class TextHighlighter {
       val lastCharWidth = editor.component.getFontMetrics(font).charWidth(char)
 
       g.color = AceConfig.textHighlightColor
-      g.fillRect(pos.x, pos.y + 1, lastCharWidth, editor.lineHeight - 1)
+      g.fillRect(pos.x, pos.y, lastCharWidth, editor.lineHeight)
 
       g.color = AceConfig.tagBackgroundColor
       g.drawRect(pos.x, pos.y, lastCharWidth, editor.lineHeight)


### PR DESCRIPTION
Fixes #362.

I don't know a "proper" solution, but imo it's better than the constant eyesore :P  
Also fixes the text highlighter background starting one pixel too low.

<table>
  <tr>
    <th>OS</th>
    <th>DPI</th>
    <th>Retina</th>
    <th>Result</th>
  </tr>
  <tr>
    <td rowspan="3">Windows</td>
    <td>=&nbsp;100%</td>
    <td>✗</td>
    <td><strong>OK</strong></td>
  </tr>
  <tr>
    <td>&gt;&nbsp;100%</td>
    <td>✗</td>
    <td>A hot mess both before and after this change. I'd say anyone who uses Windows on High DPi is already used to it being an utterly terrible experience, so I'm not going to try figure this out.</td>
  </tr>
  <tr>
    <td>&gt;&nbsp;100%</td>
    <td>✓</td>
    <td><strong>OK</strong></td>
  </tr>
  <tr>
    <td rowspan="2">Linux&nbsp;(KDE)</td>
    <td>=&nbsp;100%</td>
    <td>✗</td>
    <td><strong>OK</strong></td>
  </tr>
  <tr>
    <td>&gt;&nbsp;100%</td>
    <td>✗</td>
    <td><strong>OK</strong></td>
  </tr>
  <tr>
    <td rowspan="4">Mac OS</td>
    <td>=&nbsp;100%</td>
    <td>✗</td>
    <td><strong>OK</strong></td>
  </tr>
  <tr>
    <td>&gt;&nbsp;100%</td>
    <td>✗</td>
    <td>N/A (could set >100% DPI on external monitor)</td>
  </tr>
  <tr>
    <td>=&nbsp;100%</td>
    <td>✓</td>
    <td>N/A (could not set 100% DPI on Retina)</td>
  </tr>
  <tr>
    <td>&gt;&nbsp;100%</td>
    <td>✓</td>
    <td><strong>OK</strong></td>
  </tr>
</table>
