### PR TITLE
Add bounded toggle mode classes to start jump mode before the caret or after the caret.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ map g :action AceLineAction<CR>
 ' >> ~/.ideavimrc
 ```
 
+To customize AceJump's behavior further with additional actions, see the `<action>` tags in [plugin.xml](src/main/resources/META-INF/plugin.xml). The following example shows how to activate AceJump before or after the caret.
+
+```
+" Press `S` to activate AceJump mode before the caret
+map S :action AceBackwardAction<CR>
+
+" Press `s` to activate AceJump mode after the caret
+map s :action AceForwardAction<CR>
+```
+
 To change the default keyboard shortcuts, open **File \| Settings \| Keymap \| 🔍 "AceJump" \| AceJump \|** <kbd>Enter⏎</kbd>.
 
 ![Keymap](https://cloud.githubusercontent.com/assets/175716/11760350/911aed4c-a065-11e5-8f17-49bc97ad1dad.png)

--- a/src/main/kotlin/org/acejump/action/AceAction.kt
+++ b/src/main/kotlin/org/acejump/action/AceAction.kt
@@ -51,6 +51,13 @@ sealed class AceAction: DumbAwareAction() {
   }
 
   /**
+   * Generic action type that toggles a specific [JumpMode] with [Boundaries].
+   */
+  abstract class BaseToggleBoundedJumpModeAction(private val mode: JumpMode, private val boundaries: Boundaries): AceAction() {
+    final override fun invoke(session: Session) = session.toggleJumpMode(mode, boundaries)
+  }
+
+  /**
    * Generic action type that starts a regex search.
    */
   abstract class BaseRegexSearchAction(private val pattern: Pattern, private val boundaries: Boundaries): AceAction() {
@@ -73,12 +80,17 @@ sealed class AceAction: DumbAwareAction() {
 
   // @formatter:off
 
+  // Unbounded Toggle Modes
   class ToggleJumpMode        : BaseToggleJumpModeAction(JUMP)
   class ToggleJumpEndMode     : BaseToggleJumpModeAction(JUMP_END)
   class ToggleTargetMode      : BaseToggleJumpModeAction(TARGET)
   class ToggleDeclarationMode : BaseToggleJumpModeAction(DECLARATION)
 
+  // Bounded Toggle Modes
+  class ToggleBackwardJumpMode : BaseToggleBoundedJumpModeAction(JUMP, BEFORE_CARET)
+  class ToggleForwardJumpMode  : BaseToggleBoundedJumpModeAction(JUMP, AFTER_CARET)
 
+  // Regex Modes
   class StartAllWordsMode          : BaseRegexSearchAction(ALL_WORDS, WHOLE_FILE)
   class StartAllWordsBackwardsMode : BaseRegexSearchAction(ALL_WORDS, BEFORE_CARET)
   class StartAllWordsForwardMode   : BaseRegexSearchAction(ALL_WORDS, AFTER_CARET)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -55,6 +55,12 @@
     <action id="AceReverseAction"
             class="org.acejump.action.AceAction$ActivateOrReverseCycleMode"
             text="Activate / Reverse Cycle AceJump Mode"/>
+    <action id="AceForwardAction"
+            class="org.acejump.action.AceAction$ToggleForwardJumpMode"
+            text="Start AceJump in Jump After Caret Mode"/>
+    <action id="AceBackwardAction"
+            class="org.acejump.action.AceAction$ToggleBackwardJumpMode"
+            text="Start AceJump in Jump Before Caret Mode"/>
     <action id="AceWordStartAction"
             class="org.acejump.action.AceAction$ToggleJumpMode"
             text="Start AceJump in Jump Mode"/>


### PR DESCRIPTION
This allows AceJump to have similar behavior to vim-sneak when using `AceForwardAction` and `AceBackwardAction`.