### PR TITLE
#417: Doesn't work correctly with two files open side-by-side

### DIFF
--- a/src/main/kotlin/org/acejump/action/TagJumper.kt
+++ b/src/main/kotlin/org/acejump/action/TagJumper.kt
@@ -99,8 +99,8 @@ internal class TagJumper(private val mode: JumpMode, private val searchProcessor
     private fun ensureEditorFocused(editor: Editor) {
       val project = editor.project ?: return
       val fem = FileEditorManagerEx.getInstanceEx(project)
-    
-      val window = fem.windows.firstOrNull { (it.getSelectedComposite(true)?.fileEditorManager?.selectedTextEditor) === editor }
+
+      val window = fem.windows.firstOrNull { (it.getSelectedComposite(true)?.selectedEditor) === editor }
       if (window != null && window !== fem.currentWindow) {
         fem.currentWindow = window
       }


### PR DESCRIPTION
This seems like a regression after:
https://github.com/mikravn/AceJump/commit/c070b211e3aede52aff5148bedd914d61d97f17b

I debugged it and it seems that `fileEditorManager` references the global state, not related to the specific window under iteration.