### PR TITLE
fix(compatibility): avoid 'java.lang.NoSuchFieldError: Companion' error on lower version IDEA ide

### DIFF
--- a/src/main/kotlin/org/acejump/action/AceAction.kt
+++ b/src/main/kotlin/org/acejump/action/AceAction.kt
@@ -1,17 +1,28 @@
 package org.acejump.action
 
-import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR
+import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.util.IncorrectOperationException
 import org.acejump.boundaries.Boundaries
-import org.acejump.boundaries.StandardBoundaries.*
+import org.acejump.boundaries.StandardBoundaries.AFTER_CARET
+import org.acejump.boundaries.StandardBoundaries.BEFORE_CARET
+import org.acejump.boundaries.StandardBoundaries.WHOLE_FILE
 import org.acejump.input.JumpMode
-import org.acejump.input.JumpMode.*
+import org.acejump.input.JumpMode.DECLARATION
+import org.acejump.input.JumpMode.JUMP
+import org.acejump.input.JumpMode.JUMP_END
+import org.acejump.input.JumpMode.TARGET
 import org.acejump.search.Pattern
-import org.acejump.search.Pattern.*
+import org.acejump.search.Pattern.ALL_WORDS
+import org.acejump.search.Pattern.LINE_ALL_MARKS
+import org.acejump.search.Pattern.LINE_ENDS
+import org.acejump.search.Pattern.LINE_INDENTS
+import org.acejump.search.Pattern.LINE_STARTS
 import org.acejump.session.Session
 import org.acejump.session.SessionManager
 
@@ -31,8 +42,8 @@ sealed class AceAction: DumbAwareAction() {
   
     if (project != null) {
       try {
-        val openEditors =
-          FileEditorManagerEx.getInstanceEx(project).splitters.getSelectedEditors()
+        val fem = FileEditorManager.getInstance(project) as FileEditorManagerEx
+        val openEditors = fem.splitters.getSelectedEditors()
           .mapNotNull { (it as? TextEditor)?.editor }
           .sortedBy { if (it === editor) 0 else 1 }
         invoke(SessionManager.start(editor, openEditors))

--- a/src/main/kotlin/org/acejump/action/TagJumper.kt
+++ b/src/main/kotlin/org/acejump/action/TagJumper.kt
@@ -1,22 +1,31 @@
 package org.acejump.action
 
-import com.intellij.openapi.actionSystem.*
-import com.intellij.openapi.actionSystem.IdeActions.*
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.IdeActions.ACTION_GOTO_DECLARATION
+import com.intellij.openapi.actionSystem.IdeActions.ACTION_GOTO_TYPE_DECLARATION
 import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.command.UndoConfirmationPolicy
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.actionSystem.DocCommandGroupId
+import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.fileEditor.ex.IdeDocumentHistory
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.playback.commands.ActionCommand
-import org.acejump.*
+import org.acejump.countMatchingCharacters
+import org.acejump.immutableText
 import org.acejump.input.JumpMode
-import org.acejump.input.JumpMode.*
+import org.acejump.input.JumpMode.DECLARATION
+import org.acejump.input.JumpMode.JUMP_END
+import org.acejump.input.JumpMode.TARGET
+import org.acejump.isWordPart
 import org.acejump.search.SearchProcessor
 import org.acejump.search.Tag
+import org.acejump.wordEnd
+import org.acejump.wordStart
 
 /**
  * Performs [JumpMode] navigation and actions.
@@ -28,7 +37,7 @@ internal class TagJumper(private val mode: JumpMode, private val searchProcessor
   fun visit(tag: Tag) {
     val editor = tag.editor
     val offset = tag.offset
-    
+
     if (mode === JUMP_END || mode === TARGET) {
       val chars = editor.immutableText
       val matchingChars = searchProcessor?.let { chars.countMatchingCharacters(offset, it.query.rawText) } ?: 0
@@ -95,10 +104,10 @@ internal class TagJumper(private val mode: JumpMode, private val searchProcessor
       selectionModel.setSelection(fromOffset, toOffset)
       caretModel.moveToOffset(toOffset)
     }
-  
+
     private fun ensureEditorFocused(editor: Editor) {
       val project = editor.project ?: return
-      val fem = FileEditorManagerEx.getInstanceEx(project)
+      val fem = FileEditorManager.getInstance(project) as FileEditorManagerEx
 
       val window = fem.windows.firstOrNull { (it.getSelectedComposite(false)?.selectedWithProvider?.fileEditor as? TextEditor)?.editor === editor }
       if (window != null && window !== fem.currentWindow) {


### PR DESCRIPTION
For some reason, I have to use the specific version of IDEA based ide.

I met the error while jumping to the tag, which is quite wired, the error message says "java.lang.NoSuchFieldError: Companion".

I locate the problem is occurred while calling `FileEditorManagerEx.getInstanceEx()` function, so I direct call the inner function instead, then it works.

--- git log below ---

avoid 'java.lang.NoSuchFieldError: Companion' error on lower version IDEA ide such as DevEco Studio, which related to `FileEditorManagerEx.getInstanceEx()` companion

Related issues: [#434](https://github.com/acejump/AceJump/issues/434), [#438](https://github.com/acejump/AceJump/issues/438), [#435](https://github.com/acejump/AceJump/issues/435), etc.

