### PR TITLE
Do not bundle kotlin stdlib

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,18 +2,14 @@ import org.jetbrains.changelog.Changelog.OutputType.HTML
 import org.jetbrains.changelog.date
 
 plugins {
-  idea apply true
-  kotlin("jvm") version "1.9.20-Beta"
+  idea
+  kotlin("jvm") version "1.8.20" // https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
   id("org.jetbrains.intellij") version "1.15.0"
   id("org.jetbrains.changelog") version "2.2.0"
   id("com.github.ben-manes.versions") version "0.48.0"
 }
 
 tasks {
-  compileKotlin {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_17.toString()
-  }
-
   named<Zip>("buildPlugin") {
     dependsOn("test")
     archiveFileName = "AceJump.zip"
@@ -51,11 +47,7 @@ tasks {
 }
 
 kotlin {
-  jvmToolchain {
-    run {
-      languageVersion = JavaLanguageVersion.of(17)
-    }
-  }
+  jvmToolchain(17)
   sourceSets.all {
     languageSettings.apply {
       languageVersion = "2.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
+kotlin.stdlib.default.dependency=false
+kotlin.incremental.useClasspathSnapshot=false
+
 org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
Fixes #449

Wanted to run this by you first.

1. Changed the Kotlin plugin version to match the one bundled in IDEA 2023.2 (see comment link for a table)
2. This version of the Kotlin plugin has broken incremental compilation so I disabled that too
3. According to https://kotlinlang.org/docs/gradle-configure-project.html, the toolchain notation can be shortened and it should set `jvmTarget` automatically

I ran into some issues building the plugin in `master` - if I run `buildPlugin` then it crashes on some L&F error during the `test` task... but if I run `test` on its own, and `buildPlugin` without the dependency on `test`, everything succeeds. Not sure if it's just something on my machine, but regardless it's not caused by these changes.