### PR TITLE
Do not assign tags inside folded regions

### DIFF
--- a/src/main/kotlin/org/acejump/search/Solver.kt
+++ b/src/main/kotlin/org/acejump/search/Solver.kt
@@ -10,7 +10,7 @@ import org.acejump.immutableText
 import org.acejump.input.KeyLayoutCache
 import org.acejump.isWordPart
 import org.acejump.wordEndPlus
-import java.util.*
+import java.util.IdentityHashMap
 import kotlin.math.max
 
 /*
@@ -88,6 +88,10 @@ internal class Solver private constructor(
       val iter = offsets.iterator()
       while (iter.hasNext()) {
         val site = iter.nextInt()
+        
+        if (editor.foldingModel.isOffsetCollapsed(site)) {
+          continue
+        }
         
         for ((firstLetter, tags) in tagsByFirstLetter.entries) {
           if (canTagBeginWithChar(editor, site, firstLetter)) {

--- a/src/main/kotlin/org/acejump/search/Tag.kt
+++ b/src/main/kotlin/org/acejump/search/Tag.kt
@@ -1,5 +1,8 @@
 package org.acejump.search
 
 import com.intellij.openapi.editor.Editor
+import org.acejump.getView
 
-data class Tag(val editor: Editor, val offset: Int)
+data class Tag(val editor: Editor, val offset: Int) {
+  fun isVisible() = offset in editor.getView() && !editor.foldingModel.isOffsetCollapsed(offset)
+}

--- a/src/main/kotlin/org/acejump/search/Tagger.kt
+++ b/src/main/kotlin/org/acejump/search/Tagger.kt
@@ -155,7 +155,7 @@ internal class Tagger(private val editors: List<Editor>) {
       tagPortion.isNotEmpty()
         && label.startsWith(tagPortion, ignoreCase = true)
         && isTagCompatibleWithQuery(label, tag, query)
-        && tag.offset in tag.editor.getView()
+        && tag.isVisible()
     }
 
   private fun removeResultsWithOverlappingTags(editor: Editor, offsets: IntList) {

--- a/src/main/kotlin/org/acejump/view/TagCanvas.kt
+++ b/src/main/kotlin/org/acejump/view/TagCanvas.kt
@@ -67,6 +67,7 @@ internal class TagCanvas(private val editor: Editor): JComponent(), CaretListene
 
     val cache = EditorOffsetCache.new()
     val viewRange = VISIBLE_ON_SCREEN.getOffsetRange(editor, cache)
+    val foldingModel = editor.foldingModel
     val occupied = mutableListOf<Rectangle>()
 
     // If there is a tag at the caret location, prioritize its rendering over
@@ -82,8 +83,9 @@ internal class TagCanvas(private val editor: Editor): JComponent(), CaretListene
     val caretMarker = markers.find { it.offsetL == caretOffset || it.offsetR == caretOffset }
     caretMarker?.paint(g, editor, cache, font, occupied)
 
-    for (marker in markers)
-      if (marker.isOffsetInRange(viewRange) && marker !== caretMarker)
+    for (marker in markers) {
+      if (marker.isOffsetInRange(viewRange) && !foldingModel.isOffsetCollapsed(marker.offsetL) && marker !== caretMarker)
         marker.paint(g, editor, cache, font, occupied)
+    }
   }
 }


### PR DESCRIPTION
Closes #453

Avoids assigning tags to offsets inside folded regions until you unfold them and refine the query.  
Since the user may fold a region that already has tags, the PR also:

1. Ignores tags inside folded regions when typing
2. Skips rendering tag markers inside folded regions, otherwise it would show tags that cannot be typed

It keeps the search highlights at folded regions so you know they're there, even if it looks a little weird.

![image](https://github.com/acejump/AceJump/assets/3685160/cdba0b77-7508-4b5c-8b6d-53da4399ac74)

I didn't see a good way to consolidate the logic for `in view and not in folded region`, since typing uses `Tag` / `Tagger` and calls `editor.getView()` without any caching, and rendering uses `TagMarker` with an offset cache to determine what is in view.
